### PR TITLE
Add filter to allow override of default WP registration enabled check

### DIFF
--- a/wp-approve-user.php
+++ b/wp-approve-user.php
@@ -12,8 +12,9 @@
  * License:     GPLv2
  */
 
+$registrations_enabled = apply_filters( 'wpau_registrations_enabled', get_option( 'users_can_register' ) );
 
-if ( ! get_option( 'users_can_register' ) ) {
+if ( ! $registrations_enabled ) {
 	return;
 }
 


### PR DESCRIPTION
I use the Gravity Forms user registration add-on as the default WP registration system is prone to spam and hard to customize.

This filter will allow me to use your plugin without hacking or forking it ;-)

Usage:

add_filter( 'wpau_registrations_enabled', '__return_true' );
