### PR TITLE
Update wp-approve-user.pot

### DIFF
--- a/lang/wp-approve-user.pot
+++ b/lang/wp-approve-user.pot
@@ -58,11 +58,11 @@ msgid "Approve"
 msgstr ""
 
 #: wp-approve-user.php:174 wp-approve-user.php:227
-msgid "Unapprove"
+msgid "Reject"
 msgstr ""
 
 #: wp-approve-user.php:259
-msgid "<strong>ERROR:</strong> Your account has to be confirmed by an administrator before you can login."
+msgid "Your account must be approved before you can log in."
 msgstr ""
 
 #: wp-approve-user.php:354
@@ -73,7 +73,7 @@ msgstr[1] ""
 
 #: wp-approve-user.php:358
 msgid "User unapproved."
-msgid_plural "%d users unapproved."
+msgid_plural "%d users rejected."
 msgstr[0] ""
 msgstr[1] ""
 


### PR DESCRIPTION
Clarify and simplify English language text in interface. "Deny" and "Reject" are more correct and simpler than "Disapprove." It's not an "error" when someone tries to log in who is not yet approved or denied. "Log in" is the correct form when referring to the action of logging in where "log" is a verb. "Login" is used as a noun or adjective. https://www.grammar.com/log_in_vs._login