### PR TITLE
Add License headers and clean up readme tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.7
 Tested up to: 6.9
 Stable tag: 11
 License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Adds action links to user table to approve or unapprove user registrations.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,12 @@
 === WP Approve User ===
 Contributors: obenland
-Tags: admin, user, login, approve, user management, plugin
+Tags: admin, user, login, approve, user management
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY
 Requires at least: 4.7
 Tested up to: 6.9
 Stable tag: 11
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Adds action links to user table to approve or unapprove user registrations.
 


### PR DESCRIPTION
## Summary
- Declare GPLv2+ explicitly via `License:` and `License URI:` headers in `readme.txt`
- Drop the redundant `plugin` tag from the tag list

## Test plan
- [ ] Plugin directory page renders the license line after deploy
- [ ] Tag list no longer shows "plugin"

🤖 Generated with [Claude Code](https://claude.com/claude-code)