### PR TITLE
Fix PHPCS: rename reserved-keyword parameter $new

### DIFF
--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -1169,10 +1169,10 @@ Contact details',
 	 * @deprecated 2.3.0 - 13.08.2013
 	 * @access     public
 	 *
-	 * @param string $old Old settings value.
-	 * @param int    $new New settings value.
+	 * @param string $old       Old settings value.
+	 * @param int    $new_value New settings value.
 	 */
-	public function update_option_users_can_register( $old, $new ) {
+	public function update_option_users_can_register( $old, $new_value ) {
 		_deprecated_function( __FUNCTION__, '2.3' );
 	}
 

--- a/noop.php
+++ b/noop.php
@@ -11,11 +11,11 @@
  * @author Konstantin Obenland
  * @since  2.2.0 - 30.03.2013
  *
- * @param bool $new New option value.
+ * @param bool $new_value New option value.
  * @return bool New option value.
  */
-function wpau_whitelist_users( $new ) {
-	if ( $new ) {
+function wpau_whitelist_users( $new_value ) {
+	if ( $new_value ) {
 		$user_ids = get_users(
 			array(
 				'blog_id' => '',
@@ -29,7 +29,7 @@ function wpau_whitelist_users( $new ) {
 		}
 	}
 
-	return $new;
+	return $new_value;
 }
 add_filter( 'pre_update_option_users_can_register', 'wpau_whitelist_users' );
 


### PR DESCRIPTION
## Summary
CI (PHPCS with warnings-as-errors) fails on two `Universal.NamingConventions.NoReservedKeywordParameterNames.newFound` warnings:
- `noop.php:17` — `wpau_whitelist_users( \$new )`
- `class-obenland-wp-approve-user.php:1175` — deprecated `update_option_users_can_register( \$old, \$new )` shim

Both renamed to `\$new_value`. Callers pass positionally, so the rename is internal.

## Test plan
- [ ] PHPCS CI green
- [ ] PHPUnit still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)