### PR TITLE
Only run asset/readme sync when those files change

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -3,6 +3,9 @@ on:
     push:
         branches:
             - trunk
+        paths:
+            - 'readme.txt'
+            - '.wordpress-org/**'
 jobs:
     trunk:
         name: Push to trunk


### PR DESCRIPTION
## Summary
- Scope the asset/readme workflow's `push` trigger with a `paths:` filter
- The 10up action only syncs `readme.txt` and `.wordpress-org/` to SVN, so code-only trunk pushes were invoking it for no effect

## Test plan
- [ ] Merge and push a code-only change; confirm "Plugin asset/readme update" does not run
- [ ] Push a `readme.txt` change; confirm the workflow runs and syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)