### PR TITLE
Add RESETLINK email placeholder

### DIFF
--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -714,7 +714,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @access public
 	 */
 	public function section_description_cb() {
-		$tags = array( 'USERNAME', 'BLOG_TITLE', 'BLOG_URL', 'LOGINLINK' );
+		$tags = array( 'USERNAME', 'BLOG_TITLE', 'BLOG_URL', 'LOGINLINK', 'RESETLINK' );
 		if ( is_multisite() ) {
 			$tags[] = 'SITE_NAME';
 		}
@@ -1031,6 +1031,22 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 			'LOGINLINK'  => wp_login_url(),
 			'USERNAME'   => $user->user_nicename,
 		);
+
+		if ( false !== strpos( $message, 'RESETLINK' ) ) {
+			$key = get_password_reset_key( $user );
+			if ( ! is_wp_error( $key ) ) {
+				$placeholders['RESETLINK'] = add_query_arg(
+					array(
+						'action' => 'rp',
+						'key'    => $key,
+						'login'  => rawurlencode( $user->user_login ),
+					),
+					network_site_url( 'wp-login.php', 'login' )
+				);
+			} else {
+				$placeholders['RESETLINK'] = wp_login_url();
+			}
+		}
 
 		if ( is_multisite() ) {
 			$placeholders['SITE_NAME'] = $GLOBALS['current_site']->site_name;

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Yes! Under Settings > Approve User, you can choose when to send an email and cus
 * Switches to a three-state approval system: approved, unapproved, and pending.
 * When a user is unapproved, they now get immediately logged out from all active sessions.
 * Uses a cron job to auto-approve more than 100 users asynchronously after plugin activation.
+* Adds a `RESETLINK` email placeholder that sends users a one-time set/reset-password URL. Props @helgatheviking.
 
 = 11 =
 * Replaced image files with inline SVGs.

--- a/tests/e2e/approve-user.spec.js
+++ b/tests/e2e/approve-user.spec.js
@@ -34,7 +34,7 @@ test.describe.serial( 'WP Approve User', () => {
 	test( 'pending user is blocked from logging in', async ( { page } ) => {
 		await loginAs( page, username, password );
 		await expect( page.locator( '#login_error' ) ).toContainText(
-			'has to be confirmed by an administrator'
+			'Your account must be confirmed before you can log in.'
 		);
 	} );
 

--- a/tests/e2e/login-gate.spec.js
+++ b/tests/e2e/login-gate.spec.js
@@ -56,7 +56,7 @@ test.describe.serial( 'WP Approve User — login gate', () => {
 		await attemptLogin( page, unapprovedUser, password );
 
 		await expect( page.locator( '#login_error' ) ).toContainText(
-			'has to be confirmed by an administrator'
+			'Your account must be confirmed before you can log in.'
 		);
 		// We never reached wp-admin.
 		await expect( page ).toHaveURL( /wp-login\.php/ );

--- a/tests/e2e/registration.spec.js
+++ b/tests/e2e/registration.spec.js
@@ -55,9 +55,9 @@ test.describe( 'WP Approve User — registration meta and message', () => {
 			await page.locator( '#wp-submit' ).click();
 
 			// wp_login_errors() rewrites the "registered" message into one that
-			// mentions administrator approval.
+			// mentions approval.
 			await expect( page.locator( '#login .message' ) ).toContainText(
-				/approval|confirmed by an administrator/i
+				'once your registration is approved'
 			);
 
 			// user_register() drops both the status and the new-registration

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -1277,6 +1277,67 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * RESETLINK is replaced with a wp-login.php password-reset URL that includes the user login.
+	 *
+	 * @covers ::populate_message
+	 */
+	public function test_populate_message_replaces_resetlink() {
+		$instance = new Obenland_Wp_Approve_User();
+		$reflect  = new ReflectionObject( $instance );
+		$method   = $reflect->getMethod( 'populate_message' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $instance, 'Reset: RESETLINK', self::$subscriber );
+
+		$this->assertStringStartsWith( 'Reset: ', $result );
+		$this->assertStringContainsString( 'wp-login.php', $result );
+		$this->assertStringContainsString( 'action=rp', $result );
+		$this->assertStringContainsString( 'key=', $result );
+		$this->assertStringContainsString( 'login=' . rawurlencode( self::$subscriber->user_login ), $result );
+		$this->assertStringNotContainsString( 'RESETLINK', $result );
+	}
+
+	/**
+	 * Messages without RESETLINK do not generate a password-reset key (no user_activation_key side effect).
+	 *
+	 * @covers ::populate_message
+	 */
+	public function test_populate_message_without_resetlink_skips_key_generation() {
+		global $wpdb;
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_userdata( $user_id );
+
+		// phpcs:disable WordPress.DB
+		$this->assertEmpty( $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM {$wpdb->users} WHERE ID = %d", $user_id ) ) );
+
+		$instance = new Obenland_Wp_Approve_User();
+		$reflect  = new ReflectionObject( $instance );
+		$method   = $reflect->getMethod( 'populate_message' );
+		$method->setAccessible( true );
+
+		$method->invoke( $instance, 'Hello USERNAME', $user );
+
+		$this->assertEmpty( $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM {$wpdb->users} WHERE ID = %d", $user_id ) ) );
+		// phpcs:enable WordPress.DB
+	}
+
+	/**
+	 * The settings section description lists RESETLINK as a supported placeholder.
+	 *
+	 * @covers ::section_description_cb
+	 */
+	public function test_section_description_advertises_resetlink() {
+		$instance = new Obenland_Wp_Approve_User();
+
+		ob_start();
+		$instance->section_description_cb();
+		$section = ob_get_clean();
+
+		$this->assertStringContainsString( 'RESETLINK', $section );
+	}
+
+	/**
 	 * Deprecated update_option_users_can_register() emits a _deprecated_function notice.
 	 *
 	 * @covers ::update_option_users_can_register

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -1335,6 +1335,31 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Falls back to the login URL when get_password_reset_key() returns a WP_Error.
+	 *
+	 * @covers ::populate_message
+	 */
+	public function test_populate_message_resetlink_falls_back_on_wp_error() {
+		$deny = function () {
+			return false;
+		};
+		add_filter( 'allow_password_reset', $deny );
+
+		$instance = new Obenland_Wp_Approve_User();
+		$reflect  = new ReflectionObject( $instance );
+		$method   = $reflect->getMethod( 'populate_message' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $instance, 'Reset: RESETLINK', self::$subscriber );
+
+		remove_filter( 'allow_password_reset', $deny );
+
+		$this->assertStringContainsString( wp_login_url(), $result );
+		$this->assertStringNotContainsString( 'action=rp', $result );
+		$this->assertStringNotContainsString( 'RESETLINK', $result );
+	}
+
+	/**
 	 * The settings section description lists RESETLINK as a supported placeholder.
 	 *
 	 * @covers ::section_description_cb

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -1282,18 +1282,30 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	 * @covers ::populate_message
 	 */
 	public function test_populate_message_replaces_resetlink() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_login' => 'foo@bar',
+				'user_email' => 'foo-bar@example.org',
+				'role'       => 'subscriber',
+			)
+		);
+
 		$instance = new Obenland_Wp_Approve_User();
 		$reflect  = new ReflectionObject( $instance );
 		$method   = $reflect->getMethod( 'populate_message' );
 		$method->setAccessible( true );
 
-		$result = $method->invoke( $instance, 'Reset: RESETLINK', self::$subscriber );
+		$result = $method->invoke( $instance, 'Reset: RESETLINK', $user );
+
+		$encoded_login = 'login=' . rawurlencode( $user->user_login );
 
 		$this->assertStringStartsWith( 'Reset: ', $result );
 		$this->assertStringContainsString( 'wp-login.php', $result );
 		$this->assertStringContainsString( 'action=rp', $result );
 		$this->assertStringContainsString( 'key=', $result );
-		$this->assertStringContainsString( 'login=' . rawurlencode( self::$subscriber->user_login ), $result );
+		$this->assertStringContainsString( $encoded_login, $result );
+		$this->assertSame( 1, substr_count( $result, $encoded_login ) );
+		$this->assertStringNotContainsString( 'login=' . rawurlencode( rawurlencode( $user->user_login ) ), $result );
 		$this->assertStringNotContainsString( 'RESETLINK', $result );
 	}
 


### PR DESCRIPTION
## Summary

- Adds a `RESETLINK` placeholder to approve/unapprove emails that renders a one-time password-reset URL via `get_password_reset_key()`
- Useful when registration auto-generates passwords — new users can set their own on first login instead of being sent to the plain login page
- Supersedes #6 (2018) from @helgatheviking, reimplemented cleanly against current trunk

## Implementation notes

- Key is only generated when `RESETLINK` appears in the message body — avoids the `user_activation_key` side effect on every approval email
- Falls back to `wp_login_url()` if `get_password_reset_key()` returns a `WP_Error`
- URL is built with `add_query_arg()` + `network_site_url( 'wp-login.php', 'login' )` — so multisite installs get the network login host

## Test plan

- [x] PHPUnit single-site — new tests pass
- [x] PHPUnit multisite — new tests pass
- [x] PHPCS clean
- [ ] Manual: approve a user with RESETLINK in the email body, click the link, confirm it lands on the set-password screen

Closes #5. Credits @helgatheviking for the original proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)