### PR TITLE
Fix wp_login_errors test assertion after copy change in #27

### DIFF
--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -615,7 +615,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Rewrites the post-registration login message to explain that administrator approval is pending.
+	 * Rewrites the post-registration login message to explain that approval is pending.
 	 *
 	 * @covers ::wp_login_errors
 	 */
@@ -625,7 +625,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 		$instance = new Obenland_Wp_Approve_User();
 		$result   = $instance->wp_login_errors( $errors );
-		$this->assertStringContainsString( 'administrator', $result->get_error_message( 'registered' ) );
+		$this->assertStringContainsString( 'once your registration is approved', $result->get_error_message( 'registered' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- #27's copy tweak replaced "administrator approves" with the current "once your registration is approved" message, but the existing test still asserted on the word "administrator" — breaking on trunk
- Updates the assertion (and the docblock) to match the current message

## Test plan

- [x] \`composer test --filter test_wp_login_errors\` — single-site
- [x] \`composer test-multisite --filter test_wp_login_errors\` — multisite

🤖 Generated with [Claude Code](https://claude.com/claude-code)