### PR TITLE
Prepare v12 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.claude/
+/.playwright-mcp
 /.phpunit.result.cache
 /coverage.xml
 /node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-approve-user",
-	"version": "11.0.0",
+	"version": "12.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-approve-user",
-			"version": "11.0.0",
+			"version": "12.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@playwright/test": "^1.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-approve-user",
-	"version": "11.0.0",
+	"version": "12.0.0",
 	"private": true,
 	"description": "Adds an approval step before new WordPress users can log in.",
 	"author": "Konstantin Obenland",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,8 @@ Tags: admin, user, login, approve, user management
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY
 Requires at least: 4.7
 Tested up to: 6.9
-Stable tag: 11
+Requires PHP: 7.4
+Stable tag: 12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -76,14 +77,27 @@ Yes! Under Settings > Approve User, you can choose when to send an email and cus
 4. Count notification and row highlight for unapproved users
 
 
+== Upgrade Notice ==
+
+= 12 =
+Migrates user approval data to a three-state system, adds a RESETLINK email placeholder, and now requires PHP 7.4+. Back up before upgrading large installs.
+
+
 == Changelog ==
 
 = 12 =
 * Bumped minimum required WordPress version to 4.7.
+* Requires PHP 7.4 or later.
 * Switches to a three-state approval system: approved, unapproved, and pending.
 * When a user is unapproved, they now get immediately logged out from all active sessions.
 * Uses a cron job to auto-approve more than 100 users asynchronously after plugin activation.
 * Adds a `RESETLINK` email placeholder that sends users a one-time set/reset-password URL. Props @helgatheviking.
+* Pending count (not unapproved count) now drives the admin menu update bubble.
+* After approving or unapproving the last user in a filtered view, the redirect now lands on All Users instead of an empty list.
+* Migrates legacy boolean approval meta on upgrade: `true` becomes `approved` and `false` becomes `pending`.
+* Fixes an issue where the upgrade routine re-ran on every admin page load due to a strict type comparison.
+* Corrected text domain on the "Pending" and "Unapproved" view labels so they can be translated.
+* Updated the login error and post-registration messages to be shorter and clearer.
 
 = 11 =
 * Replaced image files with inline SVGs.

--- a/readme.txt
+++ b/readme.txt
@@ -80,7 +80,7 @@ Yes! Under Settings > Approve User, you can choose when to send an email and cus
 == Upgrade Notice ==
 
 = 12 =
-Migrates user approval data to a three-state system, adds a RESETLINK email placeholder, and now requires PHP 7.4+. Back up before upgrading large installs.
+Migrates user approval data to a three-state system and adds a RESETLINK email placeholder. Back up before upgrading large installs.
 
 
 == Changelog ==

--- a/wp-approve-user.php
+++ b/wp-approve-user.php
@@ -8,6 +8,8 @@
  * Author URI:  http://en.wp.obenland.it/#utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-approve-user
  * Text Domain: wp-approve-user
  * Domain Path: /lang
+ * Requires at least: 4.7
+ * Requires PHP: 7.4
  * License:     GPLv2
  *
  * @package WP Approve User


### PR DESCRIPTION
## Summary

- Bumps `Stable tag` to 12 in `readme.txt` (was still 11 — this was the actual release blocker; wordpress.org would otherwise keep serving v11).
- Syncs `package.json` / `package-lock.json` to `12.0.0` so `npm run lint` / `wp-env` report the right version.
- Declares `Requires PHP: 7.4` in both `readme.txt` and the plugin header to match the Composer platform pin and the PHPCS `testVersion 7.4-` floor.
- Adds `Requires at least: 4.7` to the plugin header (it was only in `readme.txt`).
- Expands the v12 changelog to cover the work that landed after the initial three-state PR: #37 (pending-count bubble), #38 (empty-view redirect), #40 (legacy `false` → `pending` migration), #55 (strict-comparison upgrade fix), #27 (text-domain + copy changes).
- Adds an `Upgrade Notice` block pointing large installs at a backup before upgrading.

`Version: 12` in the plugin header was already correct from commit b768e34, so no change there.

## Test plan

- [ ] `npm run lint:php` passes (verified locally).
- [ ] `npm run lint:md` / `lint:pkg-json` pass (verified locally).
- [ ] CI matrix (PHP 7.4 / 8.4 × WP 6.3 / latest / trunk) stays green.
- [ ] After merge, tag `12` on trunk to trigger `.github/workflows/deploy.yml` → wordpress.org SVN sync.
- [ ] Confirm wordpress.org plugin page shows v12 as the current version once the deploy action finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)