### PR TITLE
CI: ignore PHPUnit 9 security advisories in composer audit

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,7 @@
 /.wordpress-org
 /bin
 /node_modules
+/patches
 /playwright-report
 /scripts
 /test-results

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
 		},
 		"audit": {
 			"ignore": {
-				"PKSA-5jz8-6tcw-pbk4": "PHPUnit <10.5.13; phpunit-polyfills ^1.0 requires PHPUnit ^9, and the WP test scaffold does not support PHPUnit 10+ yet.",
-				"PKSA-z3gr-8qht-p93v": "PHPUnit <10.5.13; same reason as above."
+				"PKSA-5jz8-6tcw-pbk4": "GHSA-qrr6-mg7r-m243: phpunit/phpunit <=12.5.21 (patched in 12.5.22). phpunit-polyfills ^1.0 requires PHPUnit ^9, and the WP test scaffold does not support PHPUnit 10+ yet.",
+				"PKSA-z3gr-8qht-p93v": "GHSA-qrr6-mg7r-m243: phpunit/phpunit >=13.0.0,<=13.1.5 (patched in 13.1.6). Same reason as above."
 			}
 		}
 	},

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,12 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"audit": {
+			"ignore": {
+				"PKSA-5jz8-6tcw-pbk4": "PHPUnit <10.5.13; phpunit-polyfills ^1.0 requires PHPUnit ^9, and the WP test scaffold does not support PHPUnit 10+ yet.",
+				"PKSA-z3gr-8qht-p93v": "PHPUnit <10.5.13; same reason as above."
+			}
 		}
 	},
 	"autoload-dev": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"@playwright/test": "^1.47.0",
 				"@wordpress/env": "^11.4.0",
 				"@wordpress/eslint-plugin": "^25.0.0",
-				"@wordpress/scripts": "^32.0.0"
+				"@wordpress/scripts": "^32.0.0",
+				"patch-package": "^8.0.1"
 			},
 			"engines": {
 				"node": ">=24"
@@ -9760,6 +9761,13 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.57",
 			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
@@ -14671,6 +14679,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
+			}
+		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -17859,6 +17877,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -17904,6 +17942,16 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true,
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -17988,6 +18036,16 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/kleur": {
@@ -20270,6 +20328,78 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/patch-package": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+			"integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/patch-package/node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/path-case": {
@@ -33148,6 +33278,12 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
+		"@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true
+		},
 		"@zip.js/zip.js": {
 			"version": "2.7.57",
 			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
@@ -36487,6 +36623,15 @@
 				"path-exists": "^4.0.0"
 			}
 		},
+		"find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^4.0.2"
+			}
+		},
 		"flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -38608,6 +38753,19 @@
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true
 		},
+		"json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			}
+		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -38641,6 +38799,12 @@
 				"graceful-fs": "^4.1.6",
 				"universalify": "^2.0.0"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true
 		},
 		"jsonwebtoken": {
 			"version": "9.0.3",
@@ -38709,6 +38873,15 @@
 			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
+			}
+		},
+		"klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"kleur": {
@@ -40319,6 +40492,57 @@
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"patch-package": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+			"integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+			"dev": true,
+			"requires": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"open": {
+					"version": "7.4.2",
+					"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+					"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0",
+						"is-wsl": "^2.1.1"
+					}
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"path-case": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"@playwright/test": "^1.47.0",
 		"@wordpress/env": "^11.4.0",
 		"@wordpress/eslint-plugin": "^25.0.0",
-		"@wordpress/scripts": "^32.0.0"
+		"@wordpress/scripts": "^32.0.0",
+		"patch-package": "^8.0.1"
 	},
 	"overrides": {
 		"serialize-javascript": "^7.0.5",
@@ -36,6 +37,7 @@
 		"js-yaml@<3.14.2": "^3.14.2"
 	},
 	"scripts": {
+		"postinstall": "patch-package",
 		"wp-env": "wp-env",
 		"start": "wp-env start",
 		"stop": "wp-env stop",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.47.0",
-		"@wordpress/env": "^11.4.0",
+		"@wordpress/env": "11.4.0",
 		"@wordpress/eslint-plugin": "^25.0.0",
 		"@wordpress/scripts": "^32.0.0",
 		"patch-package": "^8.0.1"

--- a/patches/@wordpress+env+11.4.0.patch
+++ b/patches/@wordpress+env+11.4.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
+index 0d9e28d..6b7a9ba 100644
+--- a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
++++ b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
+@@ -230,6 +230,7 @@ RUN rm /tmp/composer-setup.php`;
+ 	dockerFileContent += `
+ USER $HOST_UID:$HOST_GID
+ ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
++RUN composer global config audit.ignore '["PKSA-5jz8-6tcw-pbk4","PKSA-z3gr-8qht-p93v"]'
+ RUN composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+ USER root`;
+ 

--- a/patches/@wordpress+env+11.4.0.patch
+++ b/patches/@wordpress+env+11.4.0.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
-index 0d9e28d..6b7a9ba 100644
+index 0d9e28d..b6aef90 100644
 --- a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
 +++ b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
 @@ -230,6 +230,7 @@ RUN rm /tmp/composer-setup.php`;
  	dockerFileContent += `
  USER $HOST_UID:$HOST_GID
  ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
-+RUN composer global config audit.ignore '["PKSA-5jz8-6tcw-pbk4","PKSA-z3gr-8qht-p93v"]'
++RUN composer global config --json audit.ignore '["PKSA-5jz8-6tcw-pbk4","PKSA-z3gr-8qht-p93v"]'
  RUN composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
  USER root`;
  


### PR DESCRIPTION
## Summary

PHPUnit 9 (required transitively by `yoast/phpunit-polyfills ^1.0`) carries unresolved security advisories `PKSA-5jz8-6tcw-pbk4` and `PKSA-z3gr-8qht-p93v` (published 2026-04-18, GHSA-qrr6-mg7r-m243 — subprocess argument injection via unsanitized `php -d` values). The advisory affects every PHPUnit release up to 12.5.21. Reaching a patched version requires dropping PHP 7.4–8.2 from the matrix and two `yoast/phpunit-polyfills` major bumps, which isn't viable for a PHP 7.4+ plugin. The attack vector requires write access to the repo's `phpunit.xml`, so risk is negligible here.

Two layers:

1. **`composer.json`** — `audit.ignore` for the host runner's `composer update` step.
2. **`patches/@wordpress+env+11.4.0.patch`** — injects the same `audit.ignore` into `@wordpress/env`'s generated Dockerfile so the `tests-cli` container's `composer global require phpunit/phpunit` step succeeds. Applied by `patch-package` via a new `postinstall` script.

Revisit when `yoast/phpunit-polyfills ^3` lands with PHPUnit 12 support and the WP test scaffold follows.

## Test plan

- [x] `composer.json` validates
- [x] `patches/@wordpress+env+11.4.0.patch` regenerated from a clean `npm install`
- [ ] CI on this PR passes on all matrix entries
- [ ] Rebase PRs #62/#63/#64/#65 onto trunk after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)