### PR TITLE
Audit tests and bring merged coverage to 100%

### DIFF
--- a/tests/test-abilities.php
+++ b/tests/test-abilities.php
@@ -125,7 +125,7 @@ class WPAU_Abilities_Test extends WP_UnitTestCase {
 	 */
 	public function test_approve_callback_updates_meta_and_fires_action() {
 		$fired = array();
-		$spy   = function ( $user_id ) use ( &$fired ) {
+		$spy   = static function ( $user_id ) use ( &$fired ) {
 			$fired[] = $user_id;
 		};
 		add_action( 'wpau_approve', $spy );
@@ -151,7 +151,7 @@ class WPAU_Abilities_Test extends WP_UnitTestCase {
 		update_user_meta( static::$subscriber_id, 'wp-approve-user', 'approved' );
 
 		$fired = array();
-		$spy   = function ( $user_id ) use ( &$fired ) {
+		$spy   = static function ( $user_id ) use ( &$fired ) {
 			$fired[] = $user_id;
 		};
 		add_action( 'wpau_unapprove', $spy );
@@ -201,7 +201,7 @@ class WPAU_Abilities_Test extends WP_UnitTestCase {
 		 * the user confirms via email, so force the change through for tests.
 		 */
 		if ( get_bloginfo( 'admin_email' ) !== $target->user_email ) {
-			$restore_mail = function () use ( $target ) {
+			$restore_mail = static function () use ( $target ) {
 				return $target->user_email;
 			};
 			add_filter( 'pre_option_admin_email', $restore_mail );
@@ -239,7 +239,7 @@ class WPAU_Abilities_Test extends WP_UnitTestCase {
 		 * blocker below a no-op.
 		 */
 
-		$blocker = function ( $allcaps, $caps, $args ) {
+		$blocker = static function ( $allcaps, $caps, $args ) {
 			if ( isset( $args[0], $args[2] ) && 'edit_user' === $args[0] && (int) $args[2] === static::$subscriber_id ) {
 				$allcaps['edit_users'] = false;
 				foreach ( $caps as $cap ) {

--- a/tests/test-auto-approval.php
+++ b/tests/test-auto-approval.php
@@ -105,7 +105,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		update_user_meta( $user->ID, 'wp-approve-user', 'pending' );
 
 		$fired    = array();
-		$listener = function ( $id ) use ( &$fired ) {
+		$listener = static function ( $id ) use ( &$fired ) {
 			$fired[] = $id;
 		};
 		add_action( 'wpau_approve', $listener );
@@ -181,7 +181,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$user = $this->make_subscriber( 'dev@filter.test' );
 		update_user_meta( $user->ID, 'wp-approve-user', 'pending' );
 
-		$filter = function () {
+		$filter = static function () {
 			return array(
 				array(
 					'type'  => 'email_domain',
@@ -225,7 +225,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		update_user_meta( $user->ID, 'wp-approve-user', 'pending' );
 
 		$count    = 0;
-		$listener = function () use ( &$count ) {
+		$listener = static function () use ( &$count ) {
 			++$count;
 		};
 		add_action( 'wpau_approve', $listener );
@@ -284,7 +284,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		update_user_meta( $user->ID, 'wp-approve-user', 'approved' );
 
 		$fired    = 0;
-		$listener = function () use ( &$fired ) {
+		$listener = static function () use ( &$fired ) {
 			++$fired;
 		};
 		add_action( 'wpau_approve', $listener );
@@ -341,7 +341,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		update_user_meta( $user->ID, 'wp-approve-user', 'pending' );
 
 		$captured = null;
-		$filter   = function ( $rules, $user_id ) use ( &$captured ) {
+		$filter   = static function ( $rules, $user_id ) use ( &$captured ) {
 			$captured = $user_id;
 			return $rules;
 		};
@@ -394,7 +394,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$fired = 0;
 		add_action(
 			'wpau_approve',
-			function () use ( &$fired ) {
+			static function () use ( &$fired ) {
 				++$fired;
 			}
 		);
@@ -438,7 +438,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 	 * @covers ::auto_approve_rule_matches
 	 */
 	public function test_rule_matches_returns_false_for_unknown_rule_type() {
-		$filter = function () {
+		$filter = static function () {
 			return array(
 				array(
 					'type'  => 'nonsense',
@@ -713,7 +713,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 	 * @covers ::auto_approve_rule_matches
 	 */
 	public function test_email_suffix_rule_with_invalid_value_does_not_match() {
-		$filter = function () {
+		$filter = static function () {
 			return array(
 				array(
 					'type'  => 'email_suffix',
@@ -741,7 +741,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 	 * @covers ::auto_approve_rule_matches
 	 */
 	public function test_ip_range_rule_with_invalid_value_does_not_match() {
-		$filter = function () {
+		$filter = static function () {
 			return array(
 				array(
 					'type'  => 'ip_range',
@@ -770,7 +770,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 	 * @covers ::auto_approve_user
 	 */
 	public function test_auto_approve_user_handles_non_array_rules() {
-		$filter = function ( $defaults ) {
+		$filter = static function ( $defaults ) {
 			unset( $defaults['auto_approve_rules'] );
 			return $defaults;
 		};

--- a/tests/test-cron-events.php
+++ b/tests/test-cron-events.php
@@ -80,4 +80,70 @@ class WPAU_Cron_Events_Test extends WP_UnitTestCase {
 		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
 		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user-mail-sent', true ) );
 	}
+
+	/**
+	 * Honors a non-zero offset so rescheduled cron runs only touch the
+	 * users that come after the offset — earlier users are left untouched.
+	 *
+	 * Protects the batch-and-reschedule activation path: if the offset
+	 * argument is dropped, each cron run would re-process the first 100
+	 * users forever and the tail of a large install would never get approved.
+	 *
+	 * @covers ::wpau_allowlist_users
+	 */
+	public function test_allowlist_users_respects_nonzero_offset() {
+		$ids = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$ids[] = self::factory()->user->create(
+				array(
+					'user_login'      => 'offset-' . $i . '-' . wp_generate_password( 6, false ),
+					'user_email'      => 'offset-' . $i . '@example.test',
+					'user_registered' => gmdate( 'Y-m-d H:i:s', time() - ( 3 - $i ) * 3600 ),
+				)
+			);
+		}
+
+		foreach ( $ids as $id ) {
+			delete_user_meta( $id, 'wp-approve-user' );
+			delete_user_meta( $id, 'wp-approve-user-mail-sent' );
+		}
+
+		/*
+		 * Snapshot the wp-approve-user meta for every existing user before
+		 * the run. get_users() ordering across test fixtures is not stable
+		 * enough to hard-code which IDs land before/after the offset, so we
+		 * diff the per-user meta after the call and assert that exactly the
+		 * users at `offset=2..` flipped to approved.
+		 */
+		$all_ids      = get_users( array( 'fields' => 'ID' ) );
+		$before_state = array();
+		foreach ( $all_ids as $id ) {
+			$before_state[ $id ] = get_user_meta( $id, 'wp-approve-user', true );
+		}
+
+		$expected_flipped = get_users(
+			array(
+				'fields' => 'ID',
+				'number' => 100,
+				'offset' => 2,
+			)
+		);
+
+		wp_clear_scheduled_hook( 'wpau_allowlist_users_cron' );
+		wpau_allowlist_users( 2 );
+
+		foreach ( $expected_flipped as $id ) {
+			$this->assertSame( 'approved', get_user_meta( $id, 'wp-approve-user', true ) );
+		}
+
+		foreach ( $all_ids as $id ) {
+			if ( in_array( $id, $expected_flipped, true ) ) {
+				continue;
+			}
+			/* Users before the offset are untouched by this run. */
+			$this->assertSame( $before_state[ $id ], get_user_meta( $id, 'wp-approve-user', true ) );
+		}
+
+		wp_clear_scheduled_hook( 'wpau_allowlist_users_cron' );
+	}
 }

--- a/tests/test-dashboard-widget-ajax.php
+++ b/tests/test-dashboard-widget-ajax.php
@@ -99,7 +99,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 		$_POST['nonce']   = wp_create_nonce( 'wpau-dashboard-approve-' . $user_id );
 
 		$fired    = array();
-		$listener = function ( $id ) use ( &$fired ) {
+		$listener = static function ( $id ) use ( &$fired ) {
 			$fired[] = $id;
 		};
 		add_action( 'wpau_approve', $listener );
@@ -208,7 +208,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 		$_POST['nonce']   = wp_create_nonce( 'wpau-dashboard-unapprove-' . $user_id );
 
 		$fired    = array();
-		$listener = function ( $id ) use ( &$fired ) {
+		$listener = static function ( $id ) use ( &$fired ) {
 			$fired[] = $id;
 		};
 		add_action( 'wpau_unapprove', $listener );
@@ -240,7 +240,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 		$fired = 0;
 		add_action(
 			'wpau_approve',
-			function () use ( &$fired ) {
+			static function () use ( &$fired ) {
 				++$fired;
 			}
 		);
@@ -286,7 +286,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 		$fired = 0;
 		add_action(
 			'wpau_approve',
-			function () use ( &$fired ) {
+			static function () use ( &$fired ) {
 				++$fired;
 			}
 		);
@@ -335,7 +335,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 		$fired = 0;
 		add_action(
 			'wpau_unapprove',
-			function () use ( &$fired ) {
+			static function () use ( &$fired ) {
 				++$fired;
 			}
 		);

--- a/tests/test-dashboard-widget.php
+++ b/tests/test-dashboard-widget.php
@@ -263,11 +263,14 @@ class WPAU_Dashboard_Widget_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers the hooks at plugins_loaded-time.
+	 * register_hooks() wires the dashboard setup + AJAX handlers so that
+	 * wp_dashboard_setup triggers register_widget and each AJAX action routes
+	 * to its handler. The AJAX tests in test-dashboard-widget-ajax.php call
+	 * handlers directly; this test guards the wiring that connects them.
 	 *
 	 * @covers ::register_hooks
 	 */
-	public function test_register_hooks_wires_everything() {
+	public function test_register_hooks_registers_dashboard_and_ajax_callbacks() {
 		$widget = new WPAU_Dashboard_Widget();
 		$widget->register_hooks();
 

--- a/tests/test-dashboard-widget.php
+++ b/tests/test-dashboard-widget.php
@@ -263,10 +263,10 @@ class WPAU_Dashboard_Widget_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * register_hooks() wires the dashboard setup + AJAX handlers so that
-	 * wp_dashboard_setup triggers register_widget and each AJAX action routes
-	 * to its handler. The AJAX tests in test-dashboard-widget-ajax.php call
-	 * handlers directly; this test guards the wiring that connects them.
+	 * Registers the dashboard setup + AJAX handlers so that wp_dashboard_setup
+	 * triggers register_widget and each AJAX action routes to its handler. The
+	 * AJAX tests in test-dashboard-widget-ajax.php call handlers directly; this
+	 * test guards the wiring that connects them.
 	 *
 	 * @covers ::register_hooks
 	 */

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -243,12 +243,8 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	 * @covers ::get_instance
 	 */
 	public function test_get_instance_returns_same_instance() {
-		/* Reset the static so the lazy-construction branch executes. */
-		$reflect = new ReflectionClass( Obenland_Wp_Approve_User::class );
-		$prop    = $reflect->getProperty( 'instance' );
-		$prop->setAccessible( true );
-		$previous = $prop->getValue();
-		$prop->setValue( null, null );
+		$previous                           = Obenland_Wp_Approve_User::$instance;
+		Obenland_Wp_Approve_User::$instance = null;
 
 		try {
 			$first  = Obenland_Wp_Approve_User::get_instance();
@@ -258,7 +254,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 			$this->assertSame( $first, $second );
 		} finally {
 			/* Restore the original singleton so subsequent tests in the run reuse it. */
-			$prop->setValue( null, $previous );
+			Obenland_Wp_Approve_User::$instance = $previous;
 		}
 	}
 

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -250,14 +250,16 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 		$previous = $prop->getValue();
 		$prop->setValue( null, null );
 
-		$first  = Obenland_Wp_Approve_User::get_instance();
-		$second = Obenland_Wp_Approve_User::get_instance();
+		try {
+			$first  = Obenland_Wp_Approve_User::get_instance();
+			$second = Obenland_Wp_Approve_User::get_instance();
 
-		/* Restore the original singleton so subsequent tests in the run reuse it. */
-		$prop->setValue( null, $previous );
-
-		$this->assertInstanceOf( Obenland_Wp_Approve_User::class, $first );
-		$this->assertSame( $first, $second );
+			$this->assertInstanceOf( Obenland_Wp_Approve_User::class, $first );
+			$this->assertSame( $first, $second );
+		} finally {
+			/* Restore the original singleton so subsequent tests in the run reuse it. */
+			$prop->setValue( null, $previous );
+		}
 	}
 
 

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -216,26 +216,11 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Returns the same singleton from repeated get_instance() calls.
+	 * Smoke-checks that plugins_loaded() registers its hook surface.
 	 *
-	 * @covers ::get_instance
-	 */
-	public function test_get_instance_returns_singleton() {
-		Obenland_Wp_Approve_User::$instance = null;
-		$a                                  = Obenland_Wp_Approve_User::get_instance();
-		$b                                  = Obenland_Wp_Approve_User::get_instance();
-		$this->assertSame( $a, $b );
-		$this->assertInstanceOf( Obenland_Wp_Approve_User::class, $a );
-	}
-
-	/**
-	 * Tests that `plugins_loaded` wires every hook the admin flows rely on.
-	 *
-	 * This is a regression guard for the hook registration block in the
-	 * method — if any `$this->hook( ... )` line is dropped, a downstream
-	 * admin flow (row action, bulk action, settings page, row query) breaks
-	 * with a silent "nothing happened" failure. Asserting the registration
-	 * surface here catches that before the functional tests do.
+	 * Picks a representative hook — the functional tests in this file
+	 * already exercise each individual callback, so a single registration
+	 * assertion is enough to catch a complete wiring regression.
 	 *
 	 * @covers ::plugins_loaded
 	 */
@@ -244,32 +229,35 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 		$instance->plugins_loaded();
 
 		$this->assertNotFalse(
-			has_filter( 'user_row_actions', array( $instance, 'user_row_actions' ) )
-		);
-		$this->assertNotFalse(
-			has_filter( 'wp_authenticate_user', array( $instance, 'wp_authenticate_user' ) )
-		);
-		$this->assertNotFalse(
 			has_action( 'user_register', array( $instance, 'user_register' ) )
 		);
-		$this->assertNotFalse(
-			has_action( 'admin_action_wpau_approve', array( $instance, 'admin_action_wpau_approve' ) )
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_action_wpau_bulk_approve', array( $instance, 'admin_action_wpau_bulk_approve' ) )
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_action_wpau_unapprove', array( $instance, 'admin_action_wpau_unapprove' ) )
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_action_wpau_update', array( $instance, 'admin_action_wpau_update' ) )
-		);
-		$this->assertNotFalse(
-			has_action( 'wpau_approve', array( $instance, 'wpau_approve' ) )
-		);
-		$this->assertNotFalse(
-			has_action( 'delete_user', array( $instance, 'delete_user' ) )
-		);
+	}
+
+	/**
+	 * The singleton accessor returns the same initialised instance on every call.
+	 *
+	 * Production code (wp-approve-user.php) calls ::get_instance() on plugins_loaded
+	 * priority 0 and relies on every later caller reusing the same object so that
+	 * pending/unapproved counts and registered hooks are not duplicated.
+	 *
+	 * @covers ::get_instance
+	 */
+	public function test_get_instance_returns_same_instance() {
+		/* Reset the static so the lazy-construction branch executes. */
+		$reflect = new ReflectionClass( Obenland_Wp_Approve_User::class );
+		$prop    = $reflect->getProperty( 'instance' );
+		$prop->setAccessible( true );
+		$previous = $prop->getValue();
+		$prop->setValue( null, null );
+
+		$first  = Obenland_Wp_Approve_User::get_instance();
+		$second = Obenland_Wp_Approve_User::get_instance();
+
+		/* Restore the original singleton so subsequent tests in the run reuse it. */
+		$prop->setValue( null, $previous );
+
+		$this->assertInstanceOf( Obenland_Wp_Approve_User::class, $first );
+		$this->assertSame( $first, $second );
 	}
 
 
@@ -621,7 +609,16 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	 * @covers ::populate_message
 	 */
 	public function test_wpau_approve_sends_email_when_enabled() {
-		update_user_meta( self::$subscriber->ID, 'wp-approve-user-new-registration', true );
+		$user_id = self::factory()->user->create(
+			array(
+				'role'          => 'subscriber',
+				'user_login'    => 'alice',
+				'user_nicename' => 'alice',
+				'user_email'    => 'alice@example.test',
+			)
+		);
+		update_user_meta( $user_id, 'wp-approve-user', 'pending' );
+		update_user_meta( $user_id, 'wp-approve-user-new-registration', true );
 
 		update_option(
 			'wp-approve-user',
@@ -638,12 +635,12 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 		add_filter( 'wp_mail', array( $this, 'filter_wp_mail_capture' ) );
 		add_filter( 'pre_wp_mail', '__return_true' );
 
-		$instance->wpau_approve( self::$subscriber->ID );
+		$instance->wpau_approve( $user_id );
 
 		$this->assertNotEmpty( $this->captured_mail );
-		$this->assertStringContainsString( 'Hello ' . self::$subscriber->user_nicename, $this->captured_mail['message'] );
-		$this->assertEmpty( get_user_meta( self::$subscriber->ID, 'wp-approve-user-new-registration', true ) );
-		$this->assertNotEmpty( get_user_meta( self::$subscriber->ID, 'wp-approve-user-mail-sent', true ) );
+		$this->assertStringContainsString( 'Hello alice', $this->captured_mail['message'] );
+		$this->assertEmpty( get_user_meta( $user_id, 'wp-approve-user-new-registration', true ) );
+		$this->assertNotEmpty( get_user_meta( $user_id, 'wp-approve-user-mail-sent', true ) );
 	}
 
 	/**
@@ -680,8 +677,16 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	 * @covers ::delete_user
 	 */
 	public function test_delete_user_sends_unapprove_email() {
-		update_user_meta( self::$subscriber->ID, 'wp-approve-user', 'unapproved' );
-		update_user_meta( self::$subscriber->ID, 'wp-approve-user-new-registration', true );
+		$user_id = self::factory()->user->create(
+			array(
+				'role'          => 'subscriber',
+				'user_login'    => 'alice',
+				'user_nicename' => 'alice',
+				'user_email'    => 'alice-unapprove@example.test',
+			)
+		);
+		update_user_meta( $user_id, 'wp-approve-user', 'unapproved' );
+		update_user_meta( $user_id, 'wp-approve-user-new-registration', true );
 
 		update_option(
 			'wp-approve-user',
@@ -698,10 +703,10 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 		$instance = new Obenland_Wp_Approve_User();
 
-		$instance->delete_user( self::$subscriber->ID );
+		$instance->delete_user( $user_id );
 
 		$this->assertNotEmpty( $this->captured_mail );
-		$this->assertStringContainsString( 'Sorry ' . self::$subscriber->user_nicename, $this->captured_mail['message'] );
+		$this->assertStringContainsString( 'Sorry alice', $this->captured_mail['message'] );
 	}
 
 	/**
@@ -1071,6 +1076,32 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Documents the current contract: pre_user_query() only inspects the
+	 * scalar `role` query var (and `$_REQUEST['role']` when `role` is empty).
+	 * A `role__in` array containing `wpau_pending` is NOT rewritten to the
+	 * meta-based lookup — callers must use `role` to get the pseudo-role
+	 * behavior.
+	 *
+	 * This test locks in that contract so a future change (either direction)
+	 * is an explicit decision, not an accident.
+	 *
+	 * @covers ::pre_user_query
+	 */
+	public function test_pre_user_query_role_in_is_not_rewritten() {
+		$instance = $this->make_instance();
+
+		$query             = new WP_User_Query();
+		$query->query_vars = array(
+			'role'     => '',
+			'role__in' => array( 'wpau_pending' ),
+		);
+		$instance->pre_user_query( $query );
+
+		$this->assertArrayNotHasKey( 'meta_value', $query->query_vars );
+		$this->assertSame( array( 'wpau_pending' ), $query->query_vars['role__in'] );
+	}
+
+	/**
 	 * Roles outside wpau_pending and wpau_unapproved are left untouched by pre_user_query.
 	 *
 	 * @covers ::pre_user_query
@@ -1142,23 +1173,23 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	 * @covers ::populate_message
 	 */
 	public function test_populate_message_without_resetlink_skips_key_generation() {
-		global $wpdb;
-
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$user    = get_userdata( $user_id );
 
-		// phpcs:disable WordPress.DB
-		$this->assertEmpty( $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM {$wpdb->users} WHERE ID = %d", $user_id ) ) );
+		$this->assertEmpty( $user->user_activation_key );
 
 		$instance = new Obenland_Wp_Approve_User();
 		$reflect  = new ReflectionObject( $instance );
 		$method   = $reflect->getMethod( 'populate_message' );
 		$method->setAccessible( true );
 
-		$method->invoke( $instance, 'Hello USERNAME', $user );
+		$result = $method->invoke( $instance, 'Hello USERNAME', $user );
 
-		$this->assertEmpty( $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM {$wpdb->users} WHERE ID = %d", $user_id ) ) );
-		// phpcs:enable WordPress.DB
+		$this->assertStringNotContainsString( 'action=rp', $result );
+		$this->assertStringNotContainsString( 'key=', $result );
+
+		$refreshed = get_userdata( $user_id );
+		$this->assertEmpty( $refreshed->user_activation_key );
 	}
 
 	/**
@@ -1167,10 +1198,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	 * @covers ::populate_message
 	 */
 	public function test_populate_message_resetlink_falls_back_on_wp_error() {
-		$deny = function () {
-			return false;
-		};
-		add_filter( 'allow_password_reset', $deny );
+		add_filter( 'allow_password_reset', '__return_false' );
 
 		$instance = new Obenland_Wp_Approve_User();
 		$reflect  = new ReflectionObject( $instance );
@@ -1179,7 +1207,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 		$result = $method->invoke( $instance, 'Reset: RESETLINK', self::$subscriber );
 
-		remove_filter( 'allow_password_reset', $deny );
+		remove_filter( 'allow_password_reset', '__return_false' );
 
 		$this->assertStringContainsString( wp_login_url(), $result );
 		$this->assertStringNotContainsString( 'action=rp', $result );

--- a/tests/test-mark-helpers.php
+++ b/tests/test-mark-helpers.php
@@ -37,7 +37,7 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 		update_user_meta( self::$user->ID, 'wp-approve-user', 'pending' );
 
 		$fired    = array();
-		$listener = function ( $id ) use ( &$fired ) {
+		$listener = static function ( $id ) use ( &$fired ) {
 			$fired[] = $id;
 		};
 		add_action( 'wpau_approve', $listener );
@@ -82,6 +82,60 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Documents the current contract: mark_approved() always fires
+	 * `wpau_approve`, even when the user is already approved.
+	 *
+	 * The helper performs no short-circuit on existing meta, so downstream
+	 * listeners must tolerate repeated invocations. If a future change adds
+	 * idempotency, update this test to assert the new contract.
+	 *
+	 * @covers ::mark_approved
+	 */
+	public function test_mark_approved_fires_action_even_when_already_approved() {
+		update_user_meta( self::$user->ID, 'wp-approve-user', 'approved' );
+
+		$fired    = 0;
+		$listener = static function () use ( &$fired ) {
+			++$fired;
+		};
+		add_action( 'wpau_approve', $listener );
+
+		try {
+			Obenland_Wp_Approve_User::mark_approved( self::$user->ID );
+		} finally {
+			remove_action( 'wpau_approve', $listener );
+		}
+
+		$this->assertSame( 1, $fired );
+		$this->assertSame( 'approved', get_user_meta( self::$user->ID, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Documents the current contract: mark_unapproved() always fires
+	 * `wpau_unapprove`, even when the user is already unapproved.
+	 *
+	 * @covers ::mark_unapproved
+	 */
+	public function test_mark_unapproved_fires_action_even_when_already_unapproved() {
+		update_user_meta( self::$user->ID, 'wp-approve-user', 'unapproved' );
+
+		$fired    = 0;
+		$listener = static function () use ( &$fired ) {
+			++$fired;
+		};
+		add_action( 'wpau_unapprove', $listener );
+
+		try {
+			Obenland_Wp_Approve_User::mark_unapproved( self::$user->ID );
+		} finally {
+			remove_action( 'wpau_unapprove', $listener );
+		}
+
+		$this->assertSame( 1, $fired );
+		$this->assertSame( 'unapproved', get_user_meta( self::$user->ID, 'wp-approve-user', true ) );
+	}
+
+	/**
 	 * Flips meta to `unapproved`, destroys sessions, and fires `wpau_unapprove`.
 	 *
 	 * @covers ::mark_unapproved
@@ -94,7 +148,7 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $sessions->get_all() );
 
 		$fired    = array();
-		$listener = function ( $id ) use ( &$fired ) {
+		$listener = static function ( $id ) use ( &$fired ) {
 			$fired[] = $id;
 		};
 		add_action( 'wpau_unapprove', $listener );

--- a/tests/test-noop.php
+++ b/tests/test-noop.php
@@ -33,9 +33,9 @@ class WPAU_Noop_Test extends WP_UnitTestCase {
 		delete_user_meta( $user_two, 'wp-approve-user' );
 
 		$this->assertSame( 1, wpau_whitelist_users( 1 ) );
-		$this->assertEquals( 1, get_user_meta( $user_one, 'wp-approve-user', true ) );
-		$this->assertEquals( 1, get_user_meta( $user_two, 'wp-approve-user', true ) );
-		$this->assertEquals( 1, get_user_meta( $user_one, 'wp-approve-user-mail-sent', true ) );
+		$this->assertSame( '1', get_user_meta( $user_one, 'wp-approve-user', true ) );
+		$this->assertSame( '1', get_user_meta( $user_two, 'wp-approve-user', true ) );
+		$this->assertSame( '1', get_user_meta( $user_one, 'wp-approve-user-mail-sent', true ) );
 	}
 
 	/**

--- a/tests/test-pending-notification.php
+++ b/tests/test-pending-notification.php
@@ -76,5 +76,4 @@ class WPAU_Pending_Notification_Test extends WP_UnitTestCase {
 		$this->assertSame( $base, $email );
 		$this->assertStringNotContainsString( 'Review pending users:', $email['message'] );
 	}
-
 }

--- a/tests/test-pending-notification.php
+++ b/tests/test-pending-notification.php
@@ -77,20 +77,4 @@ class WPAU_Pending_Notification_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Review pending users:', $email['message'] );
 	}
 
-	/**
-	 * Registers the filter during plugins_loaded() so core invokes it on real registrations.
-	 *
-	 * @covers ::plugins_loaded
-	 */
-	public function test_filter_is_registered() {
-		$instance = new Obenland_Wp_Approve_User();
-		$instance->plugins_loaded();
-
-		$this->assertNotFalse(
-			has_filter(
-				'wp_new_user_notification_email_admin',
-				array( $instance, 'wp_new_user_notification_email_admin' )
-			)
-		);
-	}
 }

--- a/tests/test-plugin-loader.php
+++ b/tests/test-plugin-loader.php
@@ -39,6 +39,20 @@ class WPAU_Plugin_Loader_Test extends WP_UnitTestCase {
 		wp_approve_user_activate();
 
 		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
-		$this->assertFalse( wp_next_scheduled( 'wpau_allowlist_users_cron' ) );
+
+		/*
+		 * wpau_allowlist_users() schedules with `array( $processed )` args, so
+		 * wp_next_scheduled() with no args wouldn't detect it. Walk the cron
+		 * array instead to catch any scheduled event for this hook.
+		 */
+		$cron_array = _get_cron_array();
+		$scheduled  = false;
+		foreach ( (array) $cron_array as $events ) {
+			if ( isset( $events['wpau_allowlist_users_cron'] ) ) {
+				$scheduled = true;
+				break;
+			}
+		}
+		$this->assertFalse( $scheduled, 'Small-site activation should not leave an orphan cron.' );
 	}
 }

--- a/tests/test-plugin-loader.php
+++ b/tests/test-plugin-loader.php
@@ -39,5 +39,6 @@ class WPAU_Plugin_Loader_Test extends WP_UnitTestCase {
 		wp_approve_user_activate();
 
 		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertFalse( wp_next_scheduled( 'wpau_allowlist_users_cron' ) );
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -337,7 +337,7 @@ class WPAU_Settings_Test extends WP_UnitTestCase {
 	 * @covers ::auto_approve_rules_cb
 	 */
 	public function test_non_array_auto_approve_rules_coerced_to_empty() {
-		$filter = function ( $defaults ) {
+		$filter = static function ( $defaults ) {
 			unset( $defaults['auto_approve_rules'] );
 			return $defaults;
 		};

--- a/tests/test-upgrade.php
+++ b/tests/test-upgrade.php
@@ -72,6 +72,11 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 		update_user_meta( $user_id, 'wp-approve-user', true );
 
+		/*
+		 * On single-site, update_site_option() delegates to update_option() and
+		 * fires pre_update_option. On multisite, it uses the network-option
+		 * path, so pre_update_site_option_{$option} must also be guarded below.
+		 */
 		$guard = static function ( $value, $option ) {
 			if ( 'wpau_db_version' === $option ) {
 				self::fail( 'update_site_option should not be called when already up to date.' );
@@ -80,8 +85,14 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_update_option', $guard, 10, 2 );
 
+		$guard_network = static function () {
+			self::fail( 'update_site_option should not be called when already up to date.' );
+		};
+		add_filter( 'pre_update_site_option_wpau_db_version', $guard_network );
+
 		wpau_upgrade_all();
 
+		remove_filter( 'pre_update_site_option_wpau_db_version', $guard_network );
 		remove_filter( 'pre_update_option', $guard );
 		remove_filter( 'pre_site_option_wpau_db_version', $stringify );
 

--- a/tests/test-upgrade.php
+++ b/tests/test-upgrade.php
@@ -127,13 +127,10 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Stamps all missing-meta users in a single set-based migration, even
-	 * across a larger user population.
+	 * Stamps missing-meta users as approved across a larger user population.
 	 *
-	 * Protects the INSERT…SELECT implementation against someone replacing
-	 * it with a per-user update_user_meta loop — 50 users is a low ceiling
-	 * but high enough to make a naive per-row implementation observably
-	 * slow, and serves as a regression smoke for unbounded completion.
+	 * Verifies correctness for a bulk set of users and serves as a regression
+	 * smoke that the migration completes and updates every missing-meta user.
 	 *
 	 * @covers ::wpau_upgrade_to_13
 	 */

--- a/tests/test-upgrade.php
+++ b/tests/test-upgrade.php
@@ -64,23 +64,26 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 	public function test_upgrade_all_bails_when_version_is_string_from_db() {
 		global $wpau_db_version;
 
-		update_site_option( 'wpau_db_version', $wpau_db_version );
-		wp_cache_flush();
+		$stringify = static function () use ( $wpau_db_version ) {
+			return (string) $wpau_db_version;
+		};
+		add_filter( 'pre_site_option_wpau_db_version', $stringify );
 
 		$user_id = self::factory()->user->create();
 		update_user_meta( $user_id, 'wp-approve-user', true );
 
-		$filter = function ( $value, $option ) {
+		$guard = static function ( $value, $option ) {
 			if ( 'wpau_db_version' === $option ) {
-				$this->fail( 'update_site_option should not be called when already up to date.' );
+				self::fail( 'update_site_option should not be called when already up to date.' );
 			}
 			return $value;
 		};
-		add_filter( 'pre_update_option', $filter, 10, 2 );
+		add_filter( 'pre_update_option', $guard, 10, 2 );
 
 		wpau_upgrade_all();
 
-		remove_filter( 'pre_update_option', $filter );
+		remove_filter( 'pre_update_option', $guard );
+		remove_filter( 'pre_site_option_wpau_db_version', $stringify );
 
 		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user', true ) );
 	}
@@ -121,6 +124,39 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		$this->assertSame( 'approved', get_user_meta( $approved, 'wp-approve-user', true ) );
 		$this->assertSame( 'pending', get_user_meta( $pending, 'wp-approve-user', true ) );
 		$this->assertSame( 'unapproved', get_user_meta( $unapproved, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Stamps all missing-meta users in a single set-based migration, even
+	 * across a larger user population.
+	 *
+	 * Protects the INSERT…SELECT implementation against someone replacing
+	 * it with a per-user update_user_meta loop — 50 users is a low ceiling
+	 * but high enough to make a naive per-row implementation observably
+	 * slow, and serves as a regression smoke for unbounded completion.
+	 *
+	 * @covers ::wpau_upgrade_to_13
+	 */
+	public function test_upgrade_to_13_handles_large_user_set() {
+		$ids = array();
+		for ( $i = 0; $i < 50; $i++ ) {
+			$ids[] = self::factory()->user->create(
+				array(
+					'user_login' => 'bulk-' . $i . '-' . wp_generate_password( 6, false ),
+					'user_email' => 'bulk-' . $i . '@example.test',
+				)
+			);
+		}
+
+		foreach ( $ids as $id ) {
+			delete_user_meta( $id, 'wp-approve-user' );
+		}
+
+		wpau_upgrade_to_13();
+
+		foreach ( $ids as $id ) {
+			$this->assertSame( 'approved', get_user_meta( $id, 'wp-approve-user', true ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **Audited the PHPUnit suite**: removed implementation spies and duplicate hook-surface checks, tightened oracles (`assertSame` where type matters, hard-coded email-body literals instead of reading production values back, observable-API assertions replacing raw `$wpdb` reads).
- **Added gap tests**: `mark_approved`/`mark_unapproved` action contract, `wpau_allowlist_users` with a non-zero offset, `pre_user_query` `role__in` contract, `wpau_upgrade_to_13` against a larger user set, and a genuinely string-typed `wpau_db_version` upgrade bail (previously tested an int).
- **Merged single-site + multisite coverage now reaches 100%**: 3/3 classes, 72/72 methods, 1138/1138 lines.
- Housekeeping: self-contained closures converted to `static function`; the `return false` closure replaced with the core `__return_false` helper; `$this->fail()` swapped for `self::fail()` so its closure can also be static.

## Test plan

- [x] `npm run test-php` — 177 tests pass
- [x] `npm run test-php-multisite` — 177 tests pass
- [x] `npm run test-php-coverage` + merge — 100% classes / methods / lines
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)