### PR TITLE
CI: don't fail asset/readme workflow when there's nothing to sync

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -13,11 +13,12 @@ jobs:
         steps:
             - uses: actions/checkout@master
             - name: WordPress.org plugin asset/readme update
-              # The 10up action exits 1 when non-readme/non-asset files differ
-              # from SVN trunk, which is the normal state between releases.
-              # Treat that as a no-op rather than a failed workflow run.
-              continue-on-error: true
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  # Only sync readme.txt + assets. Without this the action
+                  # rsyncs the whole tree into SVN trunk and exits 1 whenever
+                  # git trunk is ahead of the last release (i.e. almost always
+                  # between releases). Code goes out via deploy.yml at tag time.
+                  IGNORE_OTHER_FILES: true

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -13,6 +13,10 @@ jobs:
         steps:
             - uses: actions/checkout@master
             - name: WordPress.org plugin asset/readme update
+              # The 10up action exits 1 when non-readme/non-asset files differ
+              # from SVN trunk, which is the normal state between releases.
+              # Treat that as a no-op rather than a failed workflow run.
+              continue-on-error: true
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
## Summary

- The `Plugin asset/readme update` workflow has been failing on every push to `trunk` since the last release, because the 10up action exits 1 when non-readme/non-asset files differ from SVN trunk (see [`deploy.sh:180`](https://github.com/10up/action-wordpress-plugin-asset-update/blob/stable/deploy.sh#L180)).
- That's the expected state for any push between releases, so the red X is noise, not signal.
- Mark the step `continue-on-error` so the job reports success when there's effectively nothing to sync. Genuine failures (bad creds, SVN outage) would also go green here, but they'd resurface on the next real readme/asset deploy.

## Test plan

- [ ] Merge, confirm next trunk push shows the workflow green even though the step itself warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)