### PR TITLE
Close gaps found in test-suite audit

### DIFF
--- a/tests/test-auto-approval.php
+++ b/tests/test-auto-approval.php
@@ -546,6 +546,42 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A /32 CIDR block must match only the exact host and nothing else.
+	 *
+	 * Protects the "single host written as a CIDR" idiom that admins
+	 * sometimes use for parity with allowlist formats.
+	 *
+	 * @covers ::ip_in_range
+	 */
+	public function test_ip_in_range_slash_32_matches_exact_host_only() {
+		$this->assertTrue( Obenland_Wp_Approve_User::ip_in_range( '10.0.0.5', '10.0.0.5/32' ) );
+		$this->assertFalse( Obenland_Wp_Approve_User::ip_in_range( '10.0.0.6', '10.0.0.5/32' ) );
+		$this->assertFalse( Obenland_Wp_Approve_User::ip_in_range( '10.0.0.4', '10.0.0.5/32' ) );
+	}
+
+	/**
+	 * A /1 CIDR block exercises the `& 0xFFFFFFFF` sign-extension guard.
+	 *
+	 * Without the mask, `-1 << 31` produces a negative PHP_INT on 64-bit
+	 * builds and the comparison against `ip2long` (which always returns
+	 * an unsigned 32-bit value as an int) would fail for IPs in the
+	 * upper half of the address space.
+	 *
+	 * @covers ::ip_in_range
+	 */
+	public function test_ip_in_range_slash_1_respects_sign_extension_guard() {
+		/* Upper half of the IPv4 space: bit 31 is set. */
+		$this->assertTrue( Obenland_Wp_Approve_User::ip_in_range( '128.0.0.1', '128.0.0.0/1' ) );
+		$this->assertTrue( Obenland_Wp_Approve_User::ip_in_range( '200.200.200.200', '128.0.0.0/1' ) );
+		$this->assertTrue( Obenland_Wp_Approve_User::ip_in_range( '255.255.255.255', '128.0.0.0/1' ) );
+
+		/* Lower half: bit 31 is clear. */
+		$this->assertFalse( Obenland_Wp_Approve_User::ip_in_range( '127.255.255.255', '128.0.0.0/1' ) );
+		$this->assertFalse( Obenland_Wp_Approve_User::ip_in_range( '10.0.0.1', '128.0.0.0/1' ) );
+		$this->assertFalse( Obenland_Wp_Approve_User::ip_in_range( '0.0.0.0', '128.0.0.0/1' ) );
+	}
+
+	/**
 	 * An ip_range rule approves the user when their captured IP matches the range.
 	 *
 	 * @covers ::auto_approve_user

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -258,6 +258,42 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * The constructor hydrates options and, on admin, the pending/unapproved counts.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_options
+	 * @covers ::get_pending_count_cached
+	 */
+	public function test_constructor_hydrates_options_and_counts() {
+		update_option(
+			'wp-approve-user',
+			array(
+				'wpau-send-approve-email'   => true,
+				'wpau-send-unapprove-email' => false,
+				'wpau-approve-email'        => 'Hi USERNAME',
+				'wpau-unapprove-email'      => '',
+				'auto_approve_rules'        => array(),
+			)
+		);
+
+		set_current_screen( 'dashboard' );
+		$previous                           = Obenland_Wp_Approve_User::$instance;
+		Obenland_Wp_Approve_User::$instance = null;
+
+		try {
+			$instance = new Obenland_Wp_Approve_User();
+
+			$options = $instance->get_options();
+			$this->assertTrue( $options['wpau-send-approve-email'] );
+			$this->assertSame( 'Hi USERNAME', $options['wpau-approve-email'] );
+			$this->assertIsInt( $instance->get_pending_count_cached() );
+		} finally {
+			Obenland_Wp_Approve_User::$instance = $previous;
+			delete_option( 'wp-approve-user' );
+		}
+	}
+
 
 	/**
 	 * Sets a protected property on the given instance via Reflection.
@@ -919,6 +955,51 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * On the network users screen the bulk approve flow must verify the
+	 * `bulk-users-network` nonce (not the site-scoped `bulk-users` nonce)
+	 * and still apply the approved meta to the selected users.
+	 *
+	 * @covers ::admin_action_wpau_bulk_approve
+	 * @covers ::check_user
+	 */
+	public function test_admin_action_wpau_bulk_approve_on_users_network_screen() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite only.' );
+		}
+
+		$this->make_instance();
+
+		$previous_screen = get_current_screen();
+		set_current_screen( 'users-network' );
+
+		/*
+		 * On the network users screen the bulk form submits user IDs under
+		 * the `allusers` key (site-users.php) rather than `users` — matches
+		 * the key check_user() reads when current_action() is wpau_bulk_*.
+		 */
+		$_REQUEST['allusers'] = array( self::$subscriber->ID );
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'bulk-users-network' );
+
+		$this->capture_redirect();
+
+		try {
+			do_action( 'admin_action_wpau_bulk_approve' );
+			$this->fail( 'Expected redirect.' );
+		} catch ( WPAU_Redirect_Exception $e ) {
+			$this->assertStringContainsString( 'update=wpau-approved', $e->location );
+		} finally {
+			if ( $previous_screen ) {
+				set_current_screen( $previous_screen );
+			}
+		}
+
+		$this->assertSame(
+			'approved',
+			get_user_meta( self::$subscriber->ID, 'wp-approve-user', true )
+		);
+	}
+
+	/**
 	 * Bulk unapprove from the unapproved view redirects back to the unapproved list.
 	 *
 	 * @covers ::admin_action_wpau_bulk_unapprove
@@ -1113,6 +1194,61 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'administrator', $query->query_vars['role'] );
 		$this->assertArrayNotHasKey( 'meta_value', $query->query_vars );
+	}
+
+	/**
+	 * Self-unhooks after rewriting a pseudo-role query so a nested query fired
+	 * inside the meta lookup does not recurse back through the same rewrite
+	 * and call prepare_query() again.
+	 *
+	 * @covers ::pre_user_query
+	 */
+	public function test_pre_user_query_self_unhooks_after_pending_rewrite() {
+		$instance = $this->make_instance();
+
+		$this->assertNotFalse(
+			has_filter( 'pre_user_query', array( $instance, 'pre_user_query' ) ),
+			'Setup precondition: filter must be registered before the rewrite.'
+		);
+
+		$_REQUEST['role']  = 'wpau_pending';
+		$query             = new WP_User_Query();
+		$query->query_vars = array( 'role' => '' );
+		$instance->pre_user_query( $query );
+
+		$this->assertFalse(
+			has_filter( 'pre_user_query', array( $instance, 'pre_user_query' ) ),
+			'pre_user_query must unhook itself after rewriting the wpau_pending query.'
+		);
+
+		/*
+		 * A follow-up, non-pseudo-role query must therefore pass through
+		 * untouched — no second rewrite, no meta_key/meta_value injection.
+		 */
+		$second             = new WP_User_Query();
+		$second->query_vars = array( 'role' => 'administrator' );
+		$instance->pre_user_query( $second );
+
+		$this->assertSame( 'administrator', $second->query_vars['role'] );
+		$this->assertArrayNotHasKey( 'meta_value', $second->query_vars );
+	}
+
+	/**
+	 * Same self-unhook contract for the wpau_unapproved branch.
+	 *
+	 * @covers ::pre_user_query
+	 */
+	public function test_pre_user_query_self_unhooks_after_unapproved_rewrite() {
+		$instance = $this->make_instance();
+
+		$query             = new WP_User_Query();
+		$query->query_vars = array( 'role' => 'wpau_unapproved' );
+		$instance->pre_user_query( $query );
+
+		$this->assertFalse(
+			has_filter( 'pre_user_query', array( $instance, 'pre_user_query' ) ),
+			'pre_user_query must unhook itself after rewriting the wpau_unapproved query.'
+		);
 	}
 
 	/**

--- a/tests/test-mark-helpers.php
+++ b/tests/test-mark-helpers.php
@@ -53,35 +53,6 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The constructor hydrates options and, on admin, the pending/unapproved counts.
-	 *
-	 * @covers ::__construct
-	 * @covers ::get_options
-	 * @covers ::get_pending_count_cached
-	 */
-	public function test_constructor_hydrates_options_and_counts() {
-		update_option(
-			'wp-approve-user',
-			array(
-				'wpau-send-approve-email'   => true,
-				'wpau-send-unapprove-email' => false,
-				'wpau-approve-email'        => 'Hi USERNAME',
-				'wpau-unapprove-email'      => '',
-				'auto_approve_rules'        => array(),
-			)
-		);
-
-		set_current_screen( 'dashboard' );
-		Obenland_Wp_Approve_User::$instance = null;
-		$instance                           = new Obenland_Wp_Approve_User();
-
-		$options = $instance->get_options();
-		$this->assertTrue( $options['wpau-send-approve-email'] );
-		$this->assertSame( 'Hi USERNAME', $options['wpau-approve-email'] );
-		$this->assertIsInt( $instance->get_pending_count_cached() );
-	}
-
-	/**
 	 * Documents the current contract: mark_approved() always fires
 	 * `wpau_approve`, even when the user is already approved.
 	 *

--- a/tests/test-plugin-gate.php
+++ b/tests/test-plugin-gate.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Tests for the noop fallback loaded when `users_can_register` is disabled.
+ *
+ * @package wp-approve-user
+ */
+
+/**
+ * Covers runtime invariants of the registration-disabled branch.
+ */
+class WPAU_Plugin_Gate_Test extends WP_UnitTestCase {
+
+	/**
+	 * Noop.php (loaded when registration is off) must define the
+	 * mass-approval filter that enabling registration later depends on.
+	 *
+	 * If this function or its hook disappears, sites that flip
+	 * `users_can_register` from off to on will no longer retroactively
+	 * approve their existing users, and every one of those users will
+	 * be locked out at login.
+	 */
+	public function test_noop_path_defines_allowlist_callback() {
+		$this->assertTrue(
+			function_exists( 'wpau_whitelist_users' ),
+			'noop.php must define wpau_whitelist_users so the disabled-registration fallback can mass-approve users.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'pre_update_option_users_can_register', 'wpau_whitelist_users' ),
+			'wpau_whitelist_users must be attached to pre_update_option_users_can_register so it fires when registration is enabled.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to the recent 100%-coverage audit (#67). Adds regression tests for contracts that were previously uncovered and tightens a few existing tests. Merged single-site + multisite coverage stays at 100% (1138/1138 lines, 72/72 methods).

### New tests
- **`pre_user_query` self-unhook** — asserts the handler removes itself from the filter after a `wpau_pending` / `wpau_unapproved` rewrite. Guards against an infinite-loop regression if the unhook is ever refactored away.
- **Multisite `users-network` bulk approve** — exercises the `bulk-users-network` nonce branch of `set_up_role_context()`, which was previously unexercised.
- **CIDR boundary cases** — `/32` exact-host match and `128.0.0.0/1` sign-extension guard for `ip_in_range`; pins the existing `& 0xFFFFFFFF` protection against 32-bit / sign-extension bugs.
- **Registration-disabled fallback invariant** — `wpau_whitelist_users` must exist and be hooked to `pre_update_option_users_can_register` in `noop.php`, so sites that flip `users_can_register` from off to on still mass-approve existing users.

### Tweaks
- Dropped a tautological return-value assertion in `test-noop.php`.
- Moved the constructor test from `test-mark-helpers.php` into `test-main-class.php` for topical correctness.

## Test plan
- [x] `npm run test-php` — 183 tests, 8 skipped (multisite-only), 0 failures.
- [x] `npm run test-php-multisite` — 183 tests, 1 skipped (single-site-only), 0 failures.
- [x] `npm run test-php-coverage` — merged coverage at 100% (3/3 classes, 72/72 methods, 1138/1138 lines).
- [x] `npm run lint` — clean (phpcs, eslint, stylelint, markdownlint, pkg-json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)