### PR TITLE
Restore legacy boolean meta compatibility for third-party integrations

### DIFF
--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -106,7 +106,47 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 
 		load_plugin_textdomain( 'wp-approve-user', false, 'wp-approve-user/lang' );
 
+		register_meta(
+			'user',
+			'wp-approve-user',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'sanitize_callback' => array( __CLASS__, 'sanitize_status_meta' ),
+			)
+		);
+
 		$this->hook( 'plugins_loaded' );
+	}
+
+	/**
+	 * Normalizes `wp-approve-user` meta writes to the canonical three-state
+	 * string. Legacy boolean writes from pre-V12 integrations map to the
+	 * closest match; canonical values pass through untouched; unexpected
+	 * scalars are left alone so consumers see the raw value.
+	 *
+	 * Mapping mirrors `wpau_upgrade_to_12()` so an in-flight write and a
+	 * post-hoc migration land on the same string for the same input.
+	 *
+	 * @since 13
+	 *
+	 * @param mixed $meta_value Incoming value passed to update_user_meta().
+	 * @return mixed Sanitized value.
+	 */
+	public static function sanitize_status_meta( $meta_value ) {
+		if ( in_array( $meta_value, array( 'approved', 'unapproved', 'pending' ), true ) ) {
+			return $meta_value;
+		}
+
+		if ( true === $meta_value || 1 === $meta_value || '1' === $meta_value ) {
+			return 'approved';
+		}
+
+		if ( false === $meta_value || 0 === $meta_value || '0' === $meta_value || '' === $meta_value ) {
+			return 'pending';
+		}
+
+		return $meta_value;
 	}
 
 	/**

--- a/noop.php
+++ b/noop.php
@@ -24,7 +24,7 @@ function wpau_whitelist_users( $new_value ) {
 		);
 
 		foreach ( $user_ids as $user_id ) {
-			update_user_meta( $user_id, 'wp-approve-user', true );
+			update_user_meta( $user_id, 'wp-approve-user', 'approved' );
 			update_user_meta( $user_id, 'wp-approve-user-mail-sent', true );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Pending User Approvals dashboard widget now lists up to five pending users with inline Approve and Reject buttons that act via AJAX without leaving the dashboard.
 * Adds a rule-based auto-approval feature so admins can allow registrations from trusted email domains, suffixes, and IP ranges.
 * Extends the core "New User Registration" admin email with a link to the pending users screen when a registration needs approval.
+* Restores compatibility with third-party integrations (e.g. Restrict Content Pro) that still call `update_user_meta( $id, 'wp-approve-user', true|false )` by coercing legacy boolean writes to the V12 three-state strings.
 
 = 12 =
 * Bumped minimum required WordPress version to 4.7.

--- a/tests/test-noop.php
+++ b/tests/test-noop.php
@@ -21,7 +21,7 @@ class WPAU_Noop_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Marks every existing user with the legacy boolean `true` payload when registration is being enabled, matching the pre-v12 approval flag.
+	 * Marks every existing user as `'approved'` when registration is being enabled, so the main plugin's login gate recognises them on its next load.
 	 *
 	 * @covers ::wpau_whitelist_users
 	 */
@@ -33,8 +33,8 @@ class WPAU_Noop_Test extends WP_UnitTestCase {
 		delete_user_meta( $user_two, 'wp-approve-user' );
 
 		$this->assertSame( 1, wpau_whitelist_users( 1 ) );
-		$this->assertSame( '1', get_user_meta( $user_one, 'wp-approve-user', true ) );
-		$this->assertSame( '1', get_user_meta( $user_two, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', get_user_meta( $user_one, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', get_user_meta( $user_two, 'wp-approve-user', true ) );
 		$this->assertSame( '1', get_user_meta( $user_one, 'wp-approve-user-mail-sent', true ) );
 	}
 

--- a/tests/test-upgrade.php
+++ b/tests/test-upgrade.php
@@ -19,6 +19,36 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Writes a raw meta value straight to the usermeta table, bypassing
+	 * WP's meta sanitization. Used to simulate the pre-V12 DB state where
+	 * the `wp-approve-user` row held a raw boolean (stored as `"1"` / `""`).
+	 * `update_user_meta()` now coerces those writes to the canonical
+	 * three-state strings via `sanitize_status_meta()`, so the legacy state
+	 * isn't reachable through the meta API anymore.
+	 *
+	 * @param int    $user_id    User ID.
+	 * @param string $meta_value Raw meta_value to insert.
+	 */
+	private function set_raw_meta( $user_id, $meta_value ) {
+		global $wpdb;
+
+		delete_user_meta( $user_id, 'wp-approve-user' );
+
+		// phpcs:disable WordPress.DB
+		$wpdb->insert(
+			$wpdb->usermeta,
+			array(
+				'user_id'    => $user_id,
+				'meta_key'   => 'wp-approve-user',
+				'meta_value' => $meta_value,
+			)
+		);
+		// phpcs:enable WordPress.DB
+
+		wp_cache_delete( $user_id, 'user_meta' );
+	}
+
+	/**
 	 * Runs the v12 meta migration and stamps the current wpau_db_version.
 	 *
 	 * @covers ::wpau_upgrade_all
@@ -28,7 +58,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		global $wpau_db_version;
 
 		$user_id = self::factory()->user->create();
-		update_user_meta( $user_id, 'wp-approve-user', true );
+		$this->set_raw_meta( $user_id, '1' );
 
 		wpau_upgrade_all();
 
@@ -47,7 +77,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		update_site_option( 'wpau_db_version', $wpau_db_version );
 
 		$user_id = self::factory()->user->create();
-		update_user_meta( $user_id, 'wp-approve-user', true );
+		$this->set_raw_meta( $user_id, '1' );
 
 		wpau_upgrade_all();
 
@@ -70,7 +100,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		add_filter( 'pre_site_option_wpau_db_version', $stringify );
 
 		$user_id = self::factory()->user->create();
-		update_user_meta( $user_id, 'wp-approve-user', true );
+		$this->set_raw_meta( $user_id, '1' );
 
 		/*
 		 * On single-site, update_site_option() delegates to update_option() and
@@ -106,7 +136,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 	 */
 	public function test_upgrade_to_12_migrates_false_to_pending() {
 		$user_id = self::factory()->user->create();
-		update_user_meta( $user_id, 'wp-approve-user', false );
+		$this->set_raw_meta( $user_id, '' );
 
 		wpau_upgrade_to_12();
 
@@ -180,7 +210,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		$legacy  = self::factory()->user->create();
 		$missing = self::factory()->user->create();
 
-		update_user_meta( $legacy, 'wp-approve-user', true );
+		$this->set_raw_meta( $legacy, '1' );
 
 		wpau_upgrade_all();
 
@@ -202,7 +232,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		$legacy  = self::factory()->user->create();
 		$missing = self::factory()->user->create();
 
-		update_user_meta( $legacy, 'wp-approve-user', true );
+		$this->set_raw_meta( $legacy, '1' );
 
 		wpau_upgrade_all();
 

--- a/tests/test-user-meta.php
+++ b/tests/test-user-meta.php
@@ -209,7 +209,7 @@ class User_Meta extends WP_UnitTestCase {
 	 * @covers ::sanitize_status_meta
 	 */
 	public function test_sanitize_coerces_legacy_boolean_true_to_approved() {
-		// Instantiation registers the sanitize_user_meta filter.
+		// Instantiation registers the user meta sanitize callback.
 		new Obenland_Wp_Approve_User();
 
 		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );

--- a/tests/test-user-meta.php
+++ b/tests/test-user-meta.php
@@ -151,8 +151,28 @@ class User_Meta extends WP_UnitTestCase {
 	 * @covers ::wp_authenticate_user
 	 */
 	public function test_wp_authenticate_user_empty_legacy_meta_is_still_blocked() {
+		global $wpdb;
+
 		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
-		update_user_meta( $user->ID, 'wp-approve-user', false );
+
+		/*
+		 * Bypass the sanitize filter — on V12+ installs `update_user_meta()`
+		 * now coerces `false` to `'pending'`, so the legacy DB state has to
+		 * be written straight to the usermeta table.
+		 */
+		delete_user_meta( $user->ID, 'wp-approve-user' );
+		// phpcs:disable WordPress.DB
+		$wpdb->insert(
+			$wpdb->usermeta,
+			array(
+				'user_id'    => $user->ID,
+				'meta_key'   => 'wp-approve-user',
+				'meta_value' => '',
+			)
+		);
+		// phpcs:enable WordPress.DB
+		wp_cache_delete( $user->ID, 'user_meta' );
+
 		$this->assertSame( '', get_user_meta( $user->ID, 'wp-approve-user', true ) );
 		$this->assertTrue( metadata_exists( 'user', $user->ID, 'wp-approve-user' ) );
 
@@ -178,6 +198,105 @@ class User_Meta extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'wpau_confirmation_error', $result->get_error_code() );
+	}
+
+	/**
+	 * Legacy third-party integrations (e.g. Restrict Content Pro's
+	 * approve button) still call `update_user_meta( $id, 'wp-approve-user', true )`
+	 * with a boolean. Ensure the sanitize filter coerces that to the
+	 * canonical `'approved'` string so the login gate recognises the user.
+	 *
+	 * @covers ::sanitize_status_meta
+	 */
+	public function test_sanitize_coerces_legacy_boolean_true_to_approved() {
+		// Instantiation registers the sanitize_user_meta filter.
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		update_user_meta( $user->ID, 'wp-approve-user', true );
+
+		$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * The `false` side of the legacy boolean API needs to land as
+	 * `'pending'` to match `wpau_upgrade_to_12()`'s one-shot migration.
+	 *
+	 * @covers ::sanitize_status_meta
+	 */
+	public function test_sanitize_coerces_legacy_boolean_false_to_pending() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		update_user_meta( $user->ID, 'wp-approve-user', false );
+
+		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Integer and numeric-string variants of the legacy API should get
+	 * the same treatment as the raw booleans.
+	 *
+	 * @covers ::sanitize_status_meta
+	 */
+	public function test_sanitize_coerces_numeric_variants() {
+		new Obenland_Wp_Approve_User();
+
+		$one_int    = static::factory()->user->create();
+		$one_string = static::factory()->user->create();
+		$zero_int   = static::factory()->user->create();
+		$zero_str   = static::factory()->user->create();
+
+		update_user_meta( $one_int, 'wp-approve-user', 1 );
+		update_user_meta( $one_string, 'wp-approve-user', '1' );
+		update_user_meta( $zero_int, 'wp-approve-user', 0 );
+		update_user_meta( $zero_str, 'wp-approve-user', '0' );
+
+		$this->assertSame( 'approved', get_user_meta( $one_int, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', get_user_meta( $one_string, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', get_user_meta( $zero_int, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', get_user_meta( $zero_str, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Canonical three-state strings must pass through the sanitize filter
+	 * untouched — the filter only normalizes legacy values.
+	 *
+	 * @covers ::sanitize_status_meta
+	 */
+	public function test_sanitize_passes_canonical_values_through() {
+		new Obenland_Wp_Approve_User();
+
+		$approved   = static::factory()->user->create();
+		$unapproved = static::factory()->user->create();
+		$pending    = static::factory()->user->create();
+
+		update_user_meta( $approved, 'wp-approve-user', 'approved' );
+		update_user_meta( $unapproved, 'wp-approve-user', 'unapproved' );
+		update_user_meta( $pending, 'wp-approve-user', 'pending' );
+
+		$this->assertSame( 'approved', get_user_meta( $approved, 'wp-approve-user', true ) );
+		$this->assertSame( 'unapproved', get_user_meta( $unapproved, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', get_user_meta( $pending, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * End-to-end: a legacy integration that approves via boolean `true`
+	 * should unlock the login gate.
+	 *
+	 * @covers ::sanitize_status_meta
+	 * @covers ::wp_authenticate_user
+	 */
+	public function test_legacy_boolean_true_unlocks_login_gate() {
+		$class = new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		update_user_meta( $user->ID, 'wp-approve-user', 'pending' );
+
+		// Simulate a third-party integration approving via the boolean API.
+		update_user_meta( $user->ID, 'wp-approve-user', true );
+
+		$this->assertSame( $user, $class->wp_authenticate_user( $user ) );
 	}
 
 	/**

--- a/tests/test-user-meta.php
+++ b/tests/test-user-meta.php
@@ -281,6 +281,22 @@ class User_Meta extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Unexpected scalars (neither canonical three-state strings nor the
+	 * legacy boolean API) pass through untouched so data bugs surface
+	 * instead of being silently rewritten.
+	 *
+	 * @covers ::sanitize_status_meta
+	 */
+	public function test_sanitize_passes_unknown_values_through() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+		update_user_meta( $user, 'wp-approve-user', 'banana' );
+
+		$this->assertSame( 'banana', get_user_meta( $user, 'wp-approve-user', true ) );
+	}
+
+	/**
 	 * End-to-end: a legacy integration that approves via boolean `true`
 	 * should unlock the login gate.
 	 *


### PR DESCRIPTION
## Summary

- V12's switch to three-state string meta silently broke third-party integrations (notably Restrict Content Pro) that still write boolean values via `update_user_meta( $id, 'wp-approve-user', true|false )`. Those writes land as raw `"1"`/`""` in the DB, the login gate's strict `'approved' === $status` check doesn't recognise them, and the user stays blocked after an external approve.
- Registers the meta with a `sanitize_callback` that coerces legacy scalars to the canonical three-state strings (`true`/`1`/`"1"` → `'approved'`, `false`/`0`/`"0"`/`""` → `'pending'`), mirroring `wpau_upgrade_to_12()`'s one-shot migration mapping. Canonical values and unknown scalars pass through untouched.
- Updates the upgrade tests that relied on `update_user_meta()` to simulate pre-V12 DB state — with the sanitize filter active they now write straight to the `usermeta` table via a shared helper.

## Test plan

- [x] `npm run test-php` (single-site, 182 tests)
- [x] `npm run test-php-multisite` (182 tests)
- [x] `npm run lint`
- [ ] Install RCP on a wp-env instance with a pre-V12 DB, confirm the membership dashboard approve/deny buttons again flip the three-state meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)