### PR TITLE
Prepare v13 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-approve-user",
-	"version": "12.0.0",
+	"version": "13.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-approve-user",
-			"version": "12.0.0",
+			"version": "13.0.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -92,7 +92,7 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Pending User Approvals dashboard widget now lists up to five pending users with inline Approve and Reject buttons that act via AJAX without leaving the dashboard.
 * Adds a rule-based auto-approval feature so admins can allow registrations from trusted email domains, suffixes, and IP ranges.
 * Extends the core "New User Registration" admin email with a link to the pending users screen when a registration needs approval.
-* Registers the `users/approve` and `users/unapprove` abilities via the WP Abilities API so MCP clients and other integrations can drive the approval flow.
+* Registers the `wp-approve-user/approve` and `wp-approve-user/unapprove` abilities via the WP Abilities API so MCP clients and other integrations can drive the approval flow.
 * Fixes a silent lockout where users with no `wp-approve-user` meta (e.g. pre-existing users on sites that enabled registration after install) were blocked from wp-admin without any feedback.
 * Restores compatibility with third-party integrations (e.g. Restrict Content Pro) that still call `update_user_meta( $id, 'wp-approve-user', true|false )` by coercing legacy boolean writes to the V12 three-state strings.
 

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,8 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Pending User Approvals dashboard widget now lists up to five pending users with inline Approve and Reject buttons that act via AJAX without leaving the dashboard.
 * Adds a rule-based auto-approval feature so admins can allow registrations from trusted email domains, suffixes, and IP ranges.
 * Extends the core "New User Registration" admin email with a link to the pending users screen when a registration needs approval.
+* Registers the `users/approve` and `users/unapprove` abilities via the WP Abilities API so MCP clients and other integrations can drive the approval flow.
+* Fixes a silent lockout where users with no `wp-approve-user` meta (e.g. pre-existing users on sites that enabled registration after install) were blocked from wp-admin without any feedback.
 * Restores compatibility with third-party integrations (e.g. Restrict Content Pro) that still call `update_user_meta( $id, 'wp-approve-user', true|false )` by coercing legacy boolean writes to the V12 three-state strings.
 
 = 12 =


### PR DESCRIPTION
## Summary

- Bumps `package-lock.json` to `13.0.0` (`package.json` was already bumped; `Version: 13` / `Stable tag: 13` were already in place).
- Adds two missing v13 changelog entries for user-facing work that landed since v12 but wasn't captured in readme.txt:
  - #62 — silent-lockout fix for users with no `wp-approve-user` meta.
  - #63 — Abilities API registration for `users/approve` / `users/unapprove`.

All other release-critical fields were already correct:

- `wp-approve-user.php`: `Version: 13`, `$wpau_db_version = 13`, `Requires at least: 4.7`, `Requires PHP: 7.4`.
- `readme.txt`: `Stable tag: 13`, `Tested up to: 6.9`, `Upgrade Notice` block for v13, v13 changelog block (now expanded).
- `package.json`: already `13.0.0`.
- Trunk CI is green across the PHP 7.4/8.4 × WP 6.3/latest/trunk matrix, JS/CSS/docs lint, PHPCS, and Playwright single+multisite.

## Test plan

- [ ] `npm run lint` stays green.
- [ ] CI matrix stays green on this PR.
- [ ] After merge, tag `13` on trunk to trigger `.github/workflows/deploy.yml` → wordpress.org SVN sync.
- [ ] Confirm wordpress.org plugin page shows v13 once the deploy action finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)