### PR TITLE
Modernize GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
         name: New tag
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v6
             - name: WordPress Plugin Deploy
               uses: 10up/action-wordpress-plugin-deploy@stable
               env:

--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -26,16 +26,16 @@ jobs:
             WP_ENV_CORE: 'https://wordpress.org/wordpress-latest.zip'
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Setup Node.js (.nvmrc)
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   cache: npm
 
             - name: Cache Composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: composer-cache
               with:
                   path: vendor
@@ -68,7 +68,7 @@ jobs:
                   echo "EOF" >> $GITHUB_ENV
 
             - name: Find Comment
-              uses: peter-evans/find-comment@v2
+              uses: peter-evans/find-comment@v4
               id: fc
               with:
                   issue-number: ${{ github.event.pull_request.number }}
@@ -76,7 +76,7 @@ jobs:
                   body-includes: PHPUnit Coverage Report
 
             - name: Create or Update Comment
-              uses: peter-evans/create-or-update-comment@v3
+              uses: peter-evans/create-or-update-comment@v5
               with:
                   comment-id: ${{ steps.fc.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -45,16 +45,16 @@ jobs:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Setup Node.js (.nvmrc)
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   cache: npm
 
             - name: Cache Composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: composer-cache
               with:
                   path: vendor

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -11,7 +11,7 @@ jobs:
         name: Push to trunk
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v6
             - name: WordPress.org plugin asset/readme update
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -34,10 +34,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   cache: npm
@@ -46,7 +46,7 @@ jobs:
               run: npm ci
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: playwright-cache
               with:
                   path: ~/.cache/ms-playwright
@@ -68,7 +68,7 @@ jobs:
 
             - name: Upload Playwright report
               if: ${{ always() }}
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report
                   path: playwright-report/
@@ -81,10 +81,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   cache: npm
@@ -93,7 +93,7 @@ jobs:
               run: npm ci
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: playwright-cache
               with:
                   path: ~/.cache/ms-playwright
@@ -115,7 +115,7 @@ jobs:
 
             - name: Upload Playwright multisite report
               if: ${{ always() }}
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report-multisite
                   path: playwright-report/

--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -26,7 +26,7 @@ jobs:
                   tools: cs2pr
 
             - name: Cache Composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: composer-cache
               with:
                   path: vendor
@@ -49,10 +49,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   cache: npm


### PR DESCRIPTION
Modernize GitHub Actions workflow versions and formatting across this repo.

**Action version bumps to latest majors:**
- `actions/checkout`: `@master`/`@v1`/`@v3`/`@v4` → `@v6` (`@master` is unpinned and can break unannounced)
- `actions/setup-node`: `@v4` → `@v6`
- `actions/cache`: `@v4` → `@v5`
- `actions/upload-artifact`: `@v4` → `@v7`
- `actions/create-github-app-token`: `@v2` → `@v3`
- `softprops/action-gh-release`: `@v2` → `@v3`
- `peter-evans/find-comment`: `@v2` → `@v4`
- `peter-evans/create-or-update-comment`: `@v3` → `@v5`
- `ramsey/composer-install`: `@v2` → `@v4`

(Only the bumps actually present in this repo apply; the list above is the cohort-wide canonical.)

**Special migration (wp-author-slug only):**
- `actions/create-release@v1` → `softprops/action-gh-release@v3`. The original `actions/create-release` repo has been archived by GitHub; `softprops/action-gh-release` is the modern equivalent that the rest of this cohort already uses.

**Formatting:**
- Reformatted all workflow files via `npx -p prettier@3 -p @wordpress/prettier-config prettier --write '.github/workflows/*.yml'` to match the wp-scripts canonical style (4-space YAML indentation).

This is a coordinated cleanup across 10 plugin repos owned by @obenland; the version targets and formatting are identical across the cohort to keep them consistent.