### PR TITLE
Pin composer dependencies to lockfile in PHPUnit workflows

### DIFF
--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -39,11 +39,11 @@ jobs:
               id: composer-cache
               with:
                   path: vendor
-                  key: composer-coverage-${{ hashFiles('composer.json') }}
+                  key: composer-coverage-${{ hashFiles('composer.lock') }}
 
             - name: Install PHP dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'
-              run: composer update --prefer-dist --no-progress
+              run: composer install --prefer-dist --no-progress
 
             - name: Install system tools
               run: sudo apt-get update && sudo apt-get install -y libxml2-utils

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -58,11 +58,11 @@ jobs:
               id: composer-cache
               with:
                   path: vendor
-                  key: composer-php${{ matrix.php }}-${{ hashFiles('composer.json') }}
+                  key: composer-php${{ matrix.php }}-${{ hashFiles('composer.lock') }}
 
             - name: Install PHP dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'
-              run: composer update --prefer-dist --no-progress
+              run: composer install --prefer-dist --no-progress
 
             - name: npm install
               run: npm ci


### PR DESCRIPTION
## Summary

- PHPUnit + PHPUnit coverage workflows were running `composer update`, which walked transitive deps to their newest matching versions every run.
- After yoast/phpunit-polyfills was bumped to ^4.0 (#79), this pulled phpunit ^12 — which requires PHP 8.3+. The matrix includes PHP 7.4, so the install step broke trunk's PHPUnit job.
- Switch both workflows to `composer install` with the cache key based on `composer.lock`. That keeps phpunit pinned at the lockfile-recorded 9.x — the version the WP test scaffold supports (see the audit/ignore comment in `composer.json`).
- Aligns wp-approve-user with how change-from-address and wp-search-suggest already do it.

## Test plan

- [ ] PHPUnit job passes on PHP 7.4 / WP latest
- [ ] PHPUnit job passes on PHP 7.4 / WP 6.3
- [ ] PHPUnit job passes on PHP 8.4 / WP latest
- [ ] PHPUnit job passes on PHP 8.4 / WP trunk
- [ ] Coverage workflow still runs cleanly