### PR TITLE
Tighten map_action2 prefix match and sanitize wpau update arg

### DIFF
--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -712,17 +712,21 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( ! empty( $_REQUEST['action2'] ) ) {
-			$raw    = wp_unslash( $_REQUEST['action2'] );
-			$action = sanitize_key( $raw );
+			$raw = wp_unslash( $_REQUEST['action2'] );
 
 			/*
-			 * Reject anything sanitize_key() had to rewrite (case-only
-			 * differences are fine — sanitize_key() lowercases). Dispatching
-			 * the normalised form would let `wpau_<script>` slip through as
-			 * `wpau_script`, defeating the prefix gate.
+			 * Reject array input (`?action2[]=foo`) outright — `strtolower()`
+			 * would TypeError on PHP 8+. Then reject anything sanitize_key()
+			 * had to rewrite; case-only differences are fine because
+			 * sanitize_key() lowercases. Dispatching the normalised form would
+			 * let `wpau_<script>` slip through as `wpau_script`, defeating
+			 * the prefix gate.
 			 */
-			if ( strtolower( $raw ) === $action && 0 === strpos( $action, 'wpau_' ) ) {
-				do_action( "admin_action_{$action}" );
+			if ( is_string( $raw ) ) {
+				$action = sanitize_key( $raw );
+				if ( strtolower( $raw ) === $action && 0 === strpos( $action, 'wpau_' ) ) {
+					do_action( "admin_action_{$action}" );
+				}
 			}
 		}
 
@@ -793,12 +797,17 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @access public
 	 */
 	public function admin_action_wpau_update() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( empty( $_REQUEST['update'] ) ) {
 			return;
 		}
 
-		$update = sanitize_key( wp_unslash( $_REQUEST['update'] ) );
+		$raw = wp_unslash( $_REQUEST['update'] );
+		if ( ! is_string( $raw ) ) {
+			return;
+		}
+
+		$update = sanitize_key( $raw );
 		if ( '' === $update ) {
 			return;
 		}
@@ -834,7 +843,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 		// Prevent other admin action handlers from trying to handle our action.
 		$_REQUEST['action'] = -1;
 
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	}
 
 	/**

--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -709,13 +709,16 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @access public
 	 */
 	public function map_action2() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 
-		if ( ! empty( $_REQUEST['action2'] ) && false !== stripos( $_REQUEST['action2'], 'wpau_' ) ) {
-			do_action( "admin_action_{$_REQUEST['action2']}" );
+		if ( ! empty( $_REQUEST['action2'] ) ) {
+			$action2 = sanitize_key( wp_unslash( $_REQUEST['action2'] ) );
+			if ( 0 === strpos( $action2, 'wpau_' ) ) {
+				do_action( "admin_action_{$action2}" );
+			}
 		}
 
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		wp_add_inline_style( 'list-tables', '.wp-list-table.users tbody th, .wp-list-table.users tbody td { box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1); } #the-list .submitapprove { color:#007017; } #the-list .submitunapprove { color:#996800; }' );
 	}
@@ -782,14 +785,15 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @access public
 	 */
 	public function admin_action_wpau_update() {
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( empty( $_REQUEST['update'] ) ) {
 			return;
 		}
 
-		$count = absint( $_REQUEST['count'] );
+		$update = sanitize_key( wp_unslash( $_REQUEST['update'] ) );
+		$count  = isset( $_REQUEST['count'] ) ? absint( $_REQUEST['count'] ) : 0;
 
-		switch ( $_REQUEST['update'] ) {
+		switch ( $update ) {
 			case 'wpau-approved':
 				/* translators: Number of users. */
 				$message = esc_html( _n( '%d User approved.', '%d users approved.', $count, 'wp-approve-user' ) );
@@ -801,13 +805,13 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 				break;
 
 			default:
-				$message = apply_filters( 'wpau_update_message_handler', '', $_REQUEST['update'] );
+				$message = apply_filters( 'wpau_update_message_handler', '', $update );
 		}
 
 		if ( isset( $message ) ) {
 			add_settings_error(
 				$this->textdomain,
-				esc_attr( $_REQUEST['update'] ),
+				$update,
 				sprintf( $message, $count ),
 				'updated'
 			);
@@ -818,7 +822,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 		// Prevent other admin action handlers from trying to handle our action.
 		$_REQUEST['action'] = -1;
 
-		// phpcs:enable WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**

--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -709,16 +709,24 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @access public
 	 */
 	public function map_action2() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( ! empty( $_REQUEST['action2'] ) ) {
-			$action2 = sanitize_key( wp_unslash( $_REQUEST['action2'] ) );
-			if ( 0 === strpos( $action2, 'wpau_' ) ) {
-				do_action( "admin_action_{$action2}" );
+			$raw    = wp_unslash( $_REQUEST['action2'] );
+			$action = sanitize_key( $raw );
+
+			/*
+			 * Reject anything sanitize_key() had to rewrite (case-only
+			 * differences are fine — sanitize_key() lowercases). Dispatching
+			 * the normalised form would let `wpau_<script>` slip through as
+			 * `wpau_script`, defeating the prefix gate.
+			 */
+			if ( strtolower( $raw ) === $action && 0 === strpos( $action, 'wpau_' ) ) {
+				do_action( "admin_action_{$action}" );
 			}
 		}
 
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		wp_add_inline_style( 'list-tables', '.wp-list-table.users tbody th, .wp-list-table.users tbody td { box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1); } #the-list .submitapprove { color:#007017; } #the-list .submitunapprove { color:#996800; }' );
 	}
@@ -791,7 +799,11 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 		}
 
 		$update = sanitize_key( wp_unslash( $_REQUEST['update'] ) );
-		$count  = isset( $_REQUEST['count'] ) ? absint( $_REQUEST['count'] ) : 0;
+		if ( '' === $update ) {
+			return;
+		}
+
+		$count = isset( $_REQUEST['count'] ) ? absint( $_REQUEST['count'] ) : 0;
 
 		switch ( $update ) {
 			case 'wpau-approved':

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -582,6 +582,50 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `wpau_` must be a prefix, not a substring — values that merely contain it
+	 * mid-string (e.g. an attacker-supplied `evil_wpau_x`) must not dispatch.
+	 *
+	 * @covers ::map_action2
+	 */
+	public function test_map_action2_rejects_substring_match() {
+		$fired  = false;
+		$record = static function () use ( &$fired ) {
+			$fired = true;
+		};
+		add_action( 'admin_action_evil_wpau_action', $record );
+		$_REQUEST['action2'] = 'evil_wpau_action';
+
+		$instance = new Obenland_Wp_Approve_User();
+		$instance->map_action2();
+
+		remove_action( 'admin_action_evil_wpau_action', $record );
+
+		$this->assertFalse( $fired );
+	}
+
+	/**
+	 * Values that contain non-identifier characters after the prefix must not
+	 * dispatch, even if the prefix itself is at position 0.
+	 *
+	 * @covers ::map_action2
+	 */
+	public function test_map_action2_rejects_non_identifier_suffix() {
+		$fired  = false;
+		$record = static function () use ( &$fired ) {
+			$fired = true;
+		};
+		add_action( 'admin_action_wpau_<script>', $record );
+		$_REQUEST['action2'] = 'wpau_<script>';
+
+		$instance = new Obenland_Wp_Approve_User();
+		$instance->map_action2();
+
+		remove_action( 'admin_action_wpau_<script>', $record );
+
+		$this->assertFalse( $fired );
+	}
+
+	/**
 	 * Enqueues the plugin JS on the Users admin screen.
 	 *
 	 * @covers ::admin_print_scripts_users_php
@@ -852,6 +896,39 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	public function test_admin_action_wpau_update_returns_without_update() {
 		$instance = new Obenland_Wp_Approve_User();
 		$this->assertNull( $instance->admin_action_wpau_update() );
+	}
+
+	/**
+	 * Sanitises the `update` query arg with `sanitize_key()` before passing it
+	 * to the `wpau_update_message_handler` filter, so naive third-party
+	 * consumers cannot reflect attacker-controlled markup back into the admin.
+	 *
+	 * @covers ::admin_action_wpau_update
+	 */
+	public function test_admin_action_wpau_update_sanitizes_update_arg_passed_to_filter() {
+		global $wp_settings_errors;
+		$wp_settings_errors = array();
+
+		$_REQUEST['update'] = '<script>alert(1)</script>';
+		$_REQUEST['count']  = 0;
+
+		$captured = null;
+		$callback = static function ( $message, $update ) use ( &$captured ) {
+			$captured = $update;
+			return 'noop %d';
+		};
+		add_filter( 'wpau_update_message_handler', $callback, 10, 2 );
+
+		$instance = new Obenland_Wp_Approve_User();
+		$instance->admin_action_wpau_update();
+
+		remove_filter( 'wpau_update_message_handler', $callback, 10 );
+
+		$this->assertNotNull( $captured, 'Filter should have been called for an unknown update key.' );
+		$this->assertStringNotContainsString( '<', (string) $captured );
+		$this->assertStringNotContainsString( '>', (string) $captured );
+		$this->assertStringNotContainsString( '(', (string) $captured );
+		$this->assertStringNotContainsString( ')', (string) $captured );
 	}
 
 	/**

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -605,24 +605,32 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 	/**
 	 * Values that contain non-identifier characters after the prefix must not
-	 * dispatch, even if the prefix itself is at position 0.
+	 * dispatch, even if the prefix itself is at position 0. Registering the
+	 * tracker on the raw, sanitize_key-normalised, and prefix-only hook names
+	 * catches dispatch under any of those forms — so a sanitiser that strips
+	 * `<script>` and leaves a bare `wpau_` (which would pass the prefix gate)
+	 * is also caught.
 	 *
 	 * @covers ::map_action2
 	 */
 	public function test_map_action2_rejects_non_identifier_suffix() {
-		$fired  = false;
-		$record = static function () use ( &$fired ) {
-			$fired = true;
+		$fired_hooks = array();
+		$record      = static function () use ( &$fired_hooks ) {
+			$fired_hooks[] = current_filter();
 		};
 		add_action( 'admin_action_wpau_<script>', $record );
+		add_action( 'admin_action_wpau_script', $record );
+		add_action( 'admin_action_wpau_', $record );
 		$_REQUEST['action2'] = 'wpau_<script>';
 
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->map_action2();
 
 		remove_action( 'admin_action_wpau_<script>', $record );
+		remove_action( 'admin_action_wpau_script', $record );
+		remove_action( 'admin_action_wpau_', $record );
 
-		$this->assertFalse( $fired );
+		$this->assertSame( array(), $fired_hooks );
 	}
 
 	/**
@@ -929,6 +937,36 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '>', (string) $captured );
 		$this->assertStringNotContainsString( '(', (string) $captured );
 		$this->assertStringNotContainsString( ')', (string) $captured );
+	}
+
+	/**
+	 * Bails when the sanitised update key collapses to an empty string —
+	 * a raw value of pure punctuation must not reach the filter or
+	 * register an empty-coded settings error.
+	 *
+	 * @covers ::admin_action_wpau_update
+	 */
+	public function test_admin_action_wpau_update_bails_when_sanitized_empty() {
+		global $wp_settings_errors;
+		$wp_settings_errors = array();
+
+		$_REQUEST['update'] = '!!!';
+		$_REQUEST['count']  = 0;
+
+		$called   = false;
+		$callback = static function ( $message ) use ( &$called ) {
+			$called = true;
+			return $message;
+		};
+		add_filter( 'wpau_update_message_handler', $callback );
+
+		$instance = new Obenland_Wp_Approve_User();
+		$instance->admin_action_wpau_update();
+
+		remove_filter( 'wpau_update_message_handler', $callback );
+
+		$this->assertFalse( $called, 'Filter must not run when the sanitised update key is empty.' );
+		$this->assertEmpty( get_settings_errors( 'wp-approve-user' ) );
 	}
 
 	/**

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -634,6 +634,23 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A crafted request like `?action2[]=foo` makes `$_REQUEST['action2']`
+	 * an array. `sanitize_key()` calls `strtolower()` internally, which
+	 * fatals with TypeError on PHP 8+ when handed a non-string. Guard
+	 * against that and bail without dispatching.
+	 *
+	 * @covers ::map_action2
+	 */
+	public function test_map_action2_handles_array_input_without_fatal() {
+		$_REQUEST['action2'] = array( 'wpau_foo' );
+
+		$instance = new Obenland_Wp_Approve_User();
+		$instance->map_action2();
+
+		$this->assertTrue( true, 'map_action2() must return without a fatal when given array input.' );
+	}
+
+	/**
 	 * Enqueues the plugin JS on the Users admin screen.
 	 *
 	 * @covers ::admin_print_scripts_users_php
@@ -967,6 +984,30 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $called, 'Filter must not run when the sanitised update key is empty.' );
 		$this->assertEmpty( get_settings_errors( 'wp-approve-user' ) );
+	}
+
+	/**
+	 * A crafted request like `?update[]=x` makes `$_REQUEST['update']` an
+	 * array, which would fatal inside `sanitize_key()` on PHP 8+. The
+	 * handler must coerce or bail safely so a malformed request can't crash
+	 * the admin notice path.
+	 *
+	 * @covers ::admin_action_wpau_update
+	 */
+	public function test_admin_action_wpau_update_handles_array_input_without_fatal() {
+		global $wp_settings_errors;
+		$wp_settings_errors = array();
+
+		$_REQUEST['update'] = array( 'wpau-approved' );
+		$_REQUEST['count']  = 0;
+
+		$instance = new Obenland_Wp_Approve_User();
+		$instance->admin_action_wpau_update();
+
+		$this->assertEmpty(
+			get_settings_errors( 'wp-approve-user' ),
+			'Array input must not register a settings error.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes surfaced by a security review of the plugin. Neither was exploitable in shipped code; both remove footguns for third-party integrators.

- **`map_action2()` prefix match** — `false !== stripos( $_REQUEST['action2'], 'wpau_' )` matched `wpau_` as a substring, so a value like `evil_wpau_x` would dispatch `do_action('admin_action_evil_wpau_x')`. Switched to `sanitize_key()` + `0 === strpos()` so only identifier-shape values that *start* with `wpau_` reach `do_action()`.
- **`admin_action_wpau_update()` filter input** — `$_REQUEST['update']` was passed raw to the documented `wpau_update_message_handler` filter, which lets a careless third-party consumer reflect attacker-controlled markup back into the admin notice. The value is now sanitised once with `sanitize_key()` at the top of the handler and that sanitised value is used everywhere (switch dispatch, filter arg, and settings-error code).

The local `wpau-approved` / `wpau-unapproved` keys are already lowercase and unchanged by `sanitize_key()`. Filter consumers using non-identifier or mixed-case keys will see them normalised — that contract was always loose, and the audit explicitly flagged it as defense-in-depth worth tightening.

## Test plan

- [x] `composer test` (single-site PHPUnit) — 192 tests, 483 assertions, all green
- [x] `composer test-multisite` — 192 tests, 500 assertions, all green
- [x] `phpcs` clean on changed files
- [x] `npm run lint:js` / `lint:md` clean
- [x] New tests follow TDD — verified RED before fix, GREEN after:
  - `test_map_action2_rejects_substring_match` (e.g. `evil_wpau_action`)
  - `test_map_action2_rejects_non_identifier_suffix` (e.g. `wpau_<script>`)
  - `test_admin_action_wpau_update_sanitizes_update_arg_passed_to_filter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)