### PR TITLE
Convert readme.txt to README.md

### DIFF
--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -5,7 +5,7 @@ on:
         types: [opened, synchronize, reopened]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -5,7 +5,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'
@@ -15,7 +15,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -4,7 +4,7 @@ on:
         branches:
             - trunk
         paths:
-            - 'readme.txt'
+            - 'README.md'
             - '.wordpress-org/**'
 jobs:
     trunk:
@@ -17,7 +17,7 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-                  # Only sync readme.txt + assets. Without this the action
+                  # Only sync README.md + assets. Without this the action
                   # rsyncs the whole tree into SVN trunk and exits 1 whenever
                   # git trunk is ahead of the last release (i.e. almost always
                   # between releases). Code goes out via deploy.yml at tag time.

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,7 +5,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'
@@ -15,7 +15,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: README.md
                   sparse-checkout-cone-mode: false
 
             - name: Compare latest WordPress against readme
@@ -49,9 +49,9 @@ jobs:
                       echo "Failed to derive major.minor from '$latest'" >&2
                       exit 1
                   fi
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      echo "Could not find 'Tested up to:' header in README.md" >&2
                       exit 1
                   fi
                   sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
@@ -216,15 +216,15 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Update readme.txt
+            - name: Update README.md
               shell: bash
               env:
                   TARGET: ${{ needs.check.outputs.version }}
                   PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
-                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" README.md
+                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
@@ -241,7 +241,7 @@ jobs:
                   body: |
                       WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                      Bumps `Tested up to` in README.md from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
                   branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
@@ -294,7 +294,7 @@ jobs:
                   set -euo pipefail
                   # peter-evans/create-pull-request leaves the working tree at the pre-PR
                   # state, and the merge happens on the remote. Pull the post-merge trunk
-                  # so the SVN sync below copies the actually-bumped readme.txt rather than
+                  # so the SVN sync below copies the actually-bumped README.md rather than
                   # the workspace's stale copy.
                   git fetch origin trunk
                   git reset --hard origin/trunk

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "@wordpress/scripts/config/.markdownlint.json",
+    "MD024": { "siblings_only": true }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-=== WP Approve User ===
+# WP Approve User
 Contributors: obenland
 Tags: admin, user, login, approve, user management
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY
@@ -11,7 +11,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Adds action links to user table to approve or unapprove user registrations.
 
-== Description ==
+## Description
 
 This plugin lets you approve or reject user registrations.
 While a user is unapproved, they can't access the WordPress Admin.
@@ -19,7 +19,7 @@ While a user is unapproved, they can't access the WordPress Admin.
 On activation of the plugin, all existing users will automatically be flagged Approved. The site admin will never experience restricted access and does not need approval.
 This plugin is probably not compatible with WooCommerce.
 
-= Translations =
+### Translations
 
 I will be more than happy to update the plugin with new locales, as soon as I receive them!
 Currently available in:
@@ -32,9 +32,9 @@ Currently available in:
 * Russian
 
 
-= Plugin Hooks =
+### Plugin Hooks
 
-== Actions ==
+## Actions
 
 **wpau_approve** (*int*)
 > User-ID of approved user.
@@ -42,7 +42,7 @@ Currently available in:
 **wpau_unapprove** (*int*)
 > User-ID of unapproved user.
 
-== Filter ==
+## Filter
 
 **wpau_default_options** (*array*)
 > Default options.
@@ -54,7 +54,7 @@ Currently available in:
 > Filters the placeholders in approve/unapprove emails.
 
 
-== Installation ==
+## Installation
 
 1. Download WP Approve User.
 2. Unzip the folder into the `/wp-content/plugins/` directory.
@@ -62,14 +62,14 @@ Currently available in:
 4. Make sure user registrations is enabled in 'General Settings'.
 
 
-== Frequently Asked Questions ==
+## Frequently Asked Questions
 
-= Once a new user has been approved, will the plugin send out an email to inform them they have been approved? =
+### Once a new user has been approved, will the plugin send out an email to inform them they have been approved?
 
 Yes! Under Settings > Approve User, you can choose when to send an email and customize the email content to your needs!
 
 
-== Screenshots ==
+## Screenshots
 
 1. Error message when user is not yet approved.
 2. Row action when user is approved
@@ -77,18 +77,18 @@ Yes! Under Settings > Approve User, you can choose when to send an email and cus
 4. Count notification and row highlight for unapproved users
 
 
-== Upgrade Notice ==
+## Upgrade Notice
 
-= 13 =
+### 13
 Adds a richer Pending User Approvals dashboard widget with inline approve/reject actions and rule-based auto-approval for trusted email domains, suffixes, and IP ranges.
 
-= 12 =
+### 12
 Migrates user approval data to a three-state system and adds a RESETLINK email placeholder. Back up before upgrading large installs.
 
 
-== Changelog ==
+## Changelog
 
-= 13 =
+### 13
 * Pending User Approvals dashboard widget now lists up to five pending users with inline Approve and Reject buttons that act via AJAX without leaving the dashboard.
 * Adds a rule-based auto-approval feature so admins can allow registrations from trusted email domains, suffixes, and IP ranges.
 * Extends the core "New User Registration" admin email with a link to the pending users screen when a registration needs approval.
@@ -96,7 +96,7 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Fixes a silent lockout where users with no `wp-approve-user` meta (e.g. pre-existing users on sites that enabled registration after install) were blocked from wp-admin without any feedback.
 * Restores compatibility with third-party integrations (e.g. Restrict Content Pro) that still call `update_user_meta( $id, 'wp-approve-user', true|false )` by coercing legacy boolean writes to the V12 three-state strings.
 
-= 12 =
+### 12
 * Bumped minimum required WordPress version to 4.7.
 * Requires PHP 7.4 or later.
 * Switches to a three-state approval system: approved, unapproved, and pending.
@@ -110,37 +110,37 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Corrected text domain on the "Pending" and "Unapproved" view labels so they can be translated.
 * Updated the login error and post-registration messages to be shorter and clearer.
 
-= 11 =
+### 11
 * Replaced image files with inline SVGs.
 * Fixes a race condition with registering sidebar boxes between plugins I authored.
 
-= 10 =
+### 10
 * Fixes a bug with the activation hook creating class instances before it should. See https://wordpress.org/support/topic/fatal-error-4281/
 
-= 9 =
+### 9
 * No longer checks approval status on log in for super admins in multisite installations. See https://wordpress.org/support/topic/super-admin-not-approved-on-multisite/
 * Fixes an incompatibility with WordPress 6.1 where the plugin would set up too early. See https://wordpress.org/support/topic/fatal-error-4281/
 
-= 8 =
+### 8
 * Does no longer overwrite approval status after plugin re-activation. Props @zadro, @idearius, @howdy_mcgee.
 
-= 7 =
+### 7
 * Added a filter to manipulate placeholders and their replacement values. See https://wordpress.org/support/topic/customize-email-templates-2/
 * Only sends out rejection email if it's a new registration and the user is not approved. See https://wordpress.org/support/topic/deleting-user-generates-user-not-approved-email-possible-to-disable-feature/
 * Various multisite improvements and bug fixes. The unapproved filter works now! See https://wordpress.org/support/topic/multisite-issues-with-user-lists-and-unapproved-filter/
 
-= 6 =
+### 6
 * Improved approval flow, waiting with password email until after approval.
 * Fixed a bug where the approval email had some stray whitespace surrounding it.
 * Tested for WordPress 5.2.
 
-= 5 =
+### 5
 * Fixed a bug where user registration couldn't be activated with the plugin active.
 
-= 4 =
+### 4
 * For easier on-boarding, it now displays a notice if user registration is disabled.
 
-= 3 =
+### 3
 * Maintenance release.
 * Better multisite compatibility.
 * Now maintains role selection on batch modification.
@@ -148,44 +148,44 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Updated code to adhere to WordPress Coding Standards.
 * Tested for WordPress 5.0.
 
-= 2.3 =
+### 2.3
 * Added French translation. Props Clovis Darrigan.
 * Added Arabic translation. Props Mehdi Bounya.
 
-= 2.2.3 =
+### 2.2.3
 * Fixes a bug where administrators where locked out of their site if user registration was enabled after the plugin was.
 
-= 2.2.2 =
+### 2.2.2
 * Adds backwards compatibility for WordPress versions pre-3.5 for the user list filter.
 * Removes unused development versions of scripts and styles.
 
-= 2.2.1 =
+### 2.2.1
 * Updated utility class.
 
-= 2.2.0 =
+### 2.2.0
 * Added a way to filter for unapproved users in the admin user list.
 * Fixed a bug where currently active users would not be flagged as approved on activation if user registration was disabled.
 * Added Dutch translation. Props Jos Wolbers.
 * Minor coding convention updates to be closer to core coding guidelines.
 * Tested with the beta version of 3.6.
 
-= 2.1.1 =
+### 2.1.1
 * Fixed a bug, where new settings were not saved.
 
-= 2.1.0 =
+### 2.1.0
 * Added Russian translation. Props Mick Levin.
 * Email bodies can now be edited even when email notification is not activated.
 * Fixed a bug, where admin notices by the Settings API were not displayed.
 
-= 2.0.0 =
+### 2.0.0
 * Added the ability to send an email on approval/unapproval. Email text can be customized.
 * Optimized alteration of Users menu item. Props Rd.
 * Added Hebrew translation. Props asafche.
 
-= 1.1.1 =
+### 1.1.1
 * Fixed a bug, where the call to action bubble didn't account for newly registered.
 
-= 1.1.0 =
+### 1.1.0
 * Added bulk action for approving and unapproving users.
 * Added notification of unapproved users in admin menu item (WordPress 3.2+).
 * Added highlight of unapproved users.
@@ -194,10 +194,10 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Updated utilities class.
 * Now an instance of the Obenland_Wp_Approve_User object ist stored in a static property to make deregistration of hooks easier.
 
-= 1.0 =
+### 1.0
 * Initial Release.
 
 
-== Upgrade Notice ==
+## Upgrade Notice
 Updated registration flow, now sending out Core's password-creation email only after a registration was approved.
 With this change, the minimum required version is now WordPress 4.3.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Currently available in:
 * Russian
 
 
-### Plugin Hooks
+## Plugin Hooks
 
-## Actions
+### Actions
 
 **wpau_approve** (*int*)
 > User-ID of approved user.
@@ -42,7 +42,7 @@ Currently available in:
 **wpau_unapprove** (*int*)
 > User-ID of unapproved user.
 
-## Filter
+### Filter
 
 **wpau_default_options** (*array*)
 > Default options.
@@ -196,8 +196,3 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 
 ### 1.0
 * Initial Release.
-
-
-## Upgrade Notice
-Updated registration flow, now sending out Core's password-creation email only after a registration was approved.
-With this change, the minimum required version is now WordPress 4.3.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # WP Approve User
+
 Contributors: obenland
 Tags: admin, user, login, approve, user management
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY
+Donate link: <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY>
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 13
 License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+License URI: <https://www.gnu.org/licenses/gpl-2.0.html>
 
 Adds action links to user table to approve or unapprove user registrations.
 
@@ -80,15 +81,18 @@ Yes! Under Settings > Approve User, you can choose when to send an email and cus
 ## Upgrade Notice
 
 ### 13
+
 Adds a richer Pending User Approvals dashboard widget with inline approve/reject actions and rule-based auto-approval for trusted email domains, suffixes, and IP ranges.
 
 ### 12
+
 Migrates user approval data to a three-state system and adds a RESETLINK email placeholder. Back up before upgrading large installs.
 
 
 ## Changelog
 
 ### 13
+
 * Pending User Approvals dashboard widget now lists up to five pending users with inline Approve and Reject buttons that act via AJAX without leaving the dashboard.
 * Adds a rule-based auto-approval feature so admins can allow registrations from trusted email domains, suffixes, and IP ranges.
 * Extends the core "New User Registration" admin email with a link to the pending users screen when a registration needs approval.
@@ -97,6 +101,7 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Restores compatibility with third-party integrations (e.g. Restrict Content Pro) that still call `update_user_meta( $id, 'wp-approve-user', true|false )` by coercing legacy boolean writes to the V12 three-state strings.
 
 ### 12
+
 * Bumped minimum required WordPress version to 4.7.
 * Requires PHP 7.4 or later.
 * Switches to a three-state approval system: approved, unapproved, and pending.
@@ -111,36 +116,45 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Updated the login error and post-registration messages to be shorter and clearer.
 
 ### 11
+
 * Replaced image files with inline SVGs.
 * Fixes a race condition with registering sidebar boxes between plugins I authored.
 
 ### 10
-* Fixes a bug with the activation hook creating class instances before it should. See https://wordpress.org/support/topic/fatal-error-4281/
+
+* Fixes a bug with the activation hook creating class instances before it should. See <https://wordpress.org/support/topic/fatal-error-4281/>
 
 ### 9
-* No longer checks approval status on log in for super admins in multisite installations. See https://wordpress.org/support/topic/super-admin-not-approved-on-multisite/
-* Fixes an incompatibility with WordPress 6.1 where the plugin would set up too early. See https://wordpress.org/support/topic/fatal-error-4281/
+
+* No longer checks approval status on log in for super admins in multisite installations. See <https://wordpress.org/support/topic/super-admin-not-approved-on-multisite/>
+* Fixes an incompatibility with WordPress 6.1 where the plugin would set up too early. See <https://wordpress.org/support/topic/fatal-error-4281/>
 
 ### 8
+
 * Does no longer overwrite approval status after plugin re-activation. Props @zadro, @idearius, @howdy_mcgee.
 
 ### 7
-* Added a filter to manipulate placeholders and their replacement values. See https://wordpress.org/support/topic/customize-email-templates-2/
-* Only sends out rejection email if it's a new registration and the user is not approved. See https://wordpress.org/support/topic/deleting-user-generates-user-not-approved-email-possible-to-disable-feature/
-* Various multisite improvements and bug fixes. The unapproved filter works now! See https://wordpress.org/support/topic/multisite-issues-with-user-lists-and-unapproved-filter/
+
+* Added a filter to manipulate placeholders and their replacement values. See <https://wordpress.org/support/topic/customize-email-templates-2/>
+* Only sends out rejection email if it's a new registration and the user is not approved. See <https://wordpress.org/support/topic/deleting-user-generates-user-not-approved-email-possible-to-disable-feature/>
+* Various multisite improvements and bug fixes. The unapproved filter works now! See <https://wordpress.org/support/topic/multisite-issues-with-user-lists-and-unapproved-filter/>
 
 ### 6
+
 * Improved approval flow, waiting with password email until after approval.
 * Fixed a bug where the approval email had some stray whitespace surrounding it.
 * Tested for WordPress 5.2.
 
 ### 5
+
 * Fixed a bug where user registration couldn't be activated with the plugin active.
 
 ### 4
+
 * For easier on-boarding, it now displays a notice if user registration is disabled.
 
 ### 3
+
 * Maintenance release.
 * Better multisite compatibility.
 * Now maintains role selection on batch modification.
@@ -149,20 +163,25 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Tested for WordPress 5.0.
 
 ### 2.3
+
 * Added French translation. Props Clovis Darrigan.
 * Added Arabic translation. Props Mehdi Bounya.
 
 ### 2.2.3
+
 * Fixes a bug where administrators where locked out of their site if user registration was enabled after the plugin was.
 
 ### 2.2.2
+
 * Adds backwards compatibility for WordPress versions pre-3.5 for the user list filter.
 * Removes unused development versions of scripts and styles.
 
 ### 2.2.1
+
 * Updated utility class.
 
 ### 2.2.0
+
 * Added a way to filter for unapproved users in the admin user list.
 * Fixed a bug where currently active users would not be flagged as approved on activation if user registration was disabled.
 * Added Dutch translation. Props Jos Wolbers.
@@ -170,22 +189,27 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Tested with the beta version of 3.6.
 
 ### 2.1.1
+
 * Fixed a bug, where new settings were not saved.
 
 ### 2.1.0
+
 * Added Russian translation. Props Mick Levin.
 * Email bodies can now be edited even when email notification is not activated.
 * Fixed a bug, where admin notices by the Settings API were not displayed.
 
 ### 2.0.0
+
 * Added the ability to send an email on approval/unapproval. Email text can be customized.
 * Optimized alteration of Users menu item. Props Rd.
 * Added Hebrew translation. Props asafche.
 
 ### 1.1.1
+
 * Fixed a bug, where the call to action bubble didn't account for newly registered.
 
 ### 1.1.0
+
 * Added bulk action for approving and unapproving users.
 * Added notification of unapproved users in admin menu item (WordPress 3.2+).
 * Added highlight of unapproved users.
@@ -195,4 +219,5 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 * Now an instance of the Obenland_Wp_Approve_User object ist stored in a static property to make deregistration of hooks easier.
 
 ### 1.0
+
 * Initial Release.


### PR DESCRIPTION
## Summary

Renames `readme.txt` to `README.md` (GitHub renders it on the repo home) without giving up the wp.org plugin page.

WordPress.org's plugin-directory parser accepts either filename — its lookup regex is `!(?:^|/)readme\.(txt|md)$!i` (case-insensitive, .md included) — and the section grammar already supports `##` headers alongside `==`. The WP field block (`Contributors:`, `Tested up to:`, `Stable tag:`, …) stays in the same `Field: Value` format in both files. Within sections, `### x.y.z` becomes the changelog entry form (since `###` doesn't end a section).

Workflows that read or write the readme are updated to point at `README.md`:

- `update-tested-up-to.yml` — sparse-checkout, the `[Tt]ested up to:` sed/grep, and the PR body
- `push-asset-readme-update.yml` / `plugin-asset-update.yml` — path triggers
- `phpunit*.yml`, `playwright*.yml`, `test-e2e.yml` — `paths-ignore` arrays

For uploads-unleashed, `release.yml`'s changelog-insertion logic is also rewritten: it now greps for `^### <tag>$` and inserts after `^## Changelog`, and `.distignore` no longer excludes `README.md` from the SVN sync.

## Test plan

- [ ] GitHub renders README.md on the repo home.
- [ ] Next scheduled `update-tested-up-to` run finds the `Tested up to:` header in README.md and behaves the same as before.
- [ ] wp.org plugin page continues to show the readme content on the next deploy (parser picks up README.md via the case-insensitive lookup).
