### PR TITLE
Translate wp-approve-user reads back to legacy boolean for third parties

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Contributors: obenland
 Tags: admin, user, login, approve, user management
 Donate link: <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY>
-Requires at least: 4.7
+Requires at least: 5.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 13
+Stable tag: 14
 License: GPLv2 or later
 License URI: <https://www.gnu.org/licenses/gpl-2.0.html>
 
@@ -80,6 +80,10 @@ Yes! Under Settings > Approve User, you can choose when to send an email and cus
 
 ## Upgrade Notice
 
+### 14
+
+Finishes the V13 compatibility patch for Restrict Content Pro and similar integrations that read `wp-approve-user` meta as a boolean. Requires WordPress 5.5 or later.
+
 ### 13
 
 Adds a richer Pending User Approvals dashboard widget with inline approve/reject actions and rule-based auto-approval for trusted email domains, suffixes, and IP ranges.
@@ -90,6 +94,11 @@ Migrates user approval data to a three-state system and adds a RESETLINK email p
 
 
 ## Changelog
+
+### 14
+
+* Restores read-side compatibility for third-party integrations (notably Restrict Content Pro) that gate users with `! get_user_meta( $id, 'wp-approve-user', true )`. V13 normalized boolean writes but left reads returning the canonical strings, so pending and unapproved users still appeared "approved" to those consumers. A `get_user_metadata` filter now translates the stored three-state string back to the legacy boolean for outside callers; plugin internals read via `get_metadata_raw()` to keep seeing the raw value.
+* Bumps minimum required WordPress version to 5.5 (for `get_metadata_raw()`).
 
 ### 13
 

--- a/abilities.php
+++ b/abilities.php
@@ -163,7 +163,7 @@ function wpau_ability_approve_callback( $input ) {
 	}
 
 	update_user_meta( $user_id, 'wp-approve-user', 'approved' );
-	$status = get_user_meta( $user_id, 'wp-approve-user', true );
+	$status = Obenland_Wp_Approve_User::read_status_raw( $user_id );
 
 	/** This action is documented in class-obenland-wp-approve-user.php */
 	do_action( 'wpau_approve', $user_id );
@@ -209,7 +209,7 @@ function wpau_ability_unapprove_callback( $input ) {
 	}
 
 	update_user_meta( $user_id, 'wp-approve-user', 'unapproved' );
-	$status = get_user_meta( $user_id, 'wp-approve-user', true );
+	$status = Obenland_Wp_Approve_User::read_status_raw( $user_id );
 
 	/*
 	 * Mirror the admin UI's unapprove() behaviour — destroy all active sessions for the

--- a/class-obenland-wp-approve-user.php
+++ b/class-obenland-wp-approve-user.php
@@ -116,6 +116,8 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 			)
 		);
 
+		add_filter( 'get_user_metadata', array( __CLASS__, 'translate_status_read' ), 10, 4 );
+
 		$this->hook( 'plugins_loaded' );
 	}
 
@@ -147,6 +149,94 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 		}
 
 		return $meta_value;
+	}
+
+	/**
+	 * Reentrancy guard for the `get_user_metadata` translation filter.
+	 *
+	 * Both `get_metadata()` and `get_metadata_raw()` fire the
+	 * `get_{$meta_type}_metadata` short-circuit hook, so reading the raw
+	 * value from inside the callback or from [[read_status_raw]] would
+	 * recurse without this flag.
+	 *
+	 * @since 14
+	 *
+	 * @var bool
+	 */
+	private static $skip_translate = false;
+
+	/**
+	 * Returns the canonical three-state string in storage, bypassing the
+	 * legacy boolean translation filter.
+	 *
+	 * Plugin internals compare against `'approved'` / `'pending'` /
+	 * `'unapproved'`, so they need to see the raw value rather than the
+	 * boolean the public read filter surfaces to third parties.
+	 *
+	 * @since 14
+	 *
+	 * @param int $user_id User ID.
+	 * @return string The stored status, or '' when no meta row exists.
+	 */
+	public static function read_status_raw( $user_id ) {
+		self::$skip_translate = true;
+		try {
+			$value = get_metadata_raw( 'user', $user_id, 'wp-approve-user', true );
+		} finally {
+			self::$skip_translate = false;
+		}
+
+		return null === $value ? '' : $value;
+	}
+
+	/**
+	 * Translates `wp-approve-user` reads back to the legacy boolean API.
+	 *
+	 * Pre-V12 the meta stored `true` (approved) or `false`/missing
+	 * (pending). Third-party integrations — Restrict Content Pro is the
+	 * known consumer — still read with `! get_user_meta( $id, 'wp-approve-user', true )`,
+	 * which only works when the stored value is falsy for non-approved
+	 * users. Since V12 the meta holds truthy strings for every state, so
+	 * those consumers see every user as approved.
+	 *
+	 * This filter is the read-side counterpart to [[sanitize_status_meta]]:
+	 * `'approved'` → `true`, `'pending'`/`'unapproved'` → `false`. Plugin
+	 * internals call [[read_status_raw]] instead, which trips the
+	 * [[$skip_translate]] guard so they keep seeing the canonical string.
+	 *
+	 * Returns the array form WP core's `get_metadata()` / `get_metadata_raw()`
+	 * expect when short-circuiting: it unwraps `$check[0]` for `$single`
+	 * callers and keeps the array intact for non-single callers.
+	 *
+	 * @since 14
+	 *
+	 * @param mixed  $value     The pre-filter value (always `null` here).
+	 * @param int    $object_id User ID being read.
+	 * @param string $meta_key  Meta key being read.
+	 * @param bool   $single    Whether to return a single value.
+	 * @return mixed Translated value or the original `$value` to fall through.
+	 */
+	public static function translate_status_read( $value, $object_id, $meta_key, $single ) {
+		if ( 'wp-approve-user' !== $meta_key || self::$skip_translate ) {
+			return $value;
+		}
+
+		self::$skip_translate = true;
+		try {
+			$raw = get_metadata_raw( 'user', $object_id, 'wp-approve-user', true );
+		} finally {
+			self::$skip_translate = false;
+		}
+
+		if ( 'approved' === $raw ) {
+			return array( true );
+		}
+
+		if ( 'pending' === $raw || 'unapproved' === $raw ) {
+			return array( false );
+		}
+
+		return $value;
 	}
 
 	/**
@@ -362,7 +452,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 			$site_id = isset( $_REQUEST['id'] ) ? intval( $_REQUEST['id'] ) : 0;
 			$url     = 'site-users-network' === get_current_screen()->id ? add_query_arg( array( 'id' => $site_id ), 'site-users.php' ) : 'users.php';
 
-			$status = get_user_meta( $user_object->ID, 'wp-approve-user', true );
+			$status = self::read_status_raw( $user_object->ID );
 
 			if ( 'approved' !== $status ) {
 				$unapprove_url = wp_nonce_url(
@@ -423,7 +513,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 			return $userdata;
 		}
 
-		$status          = get_user_meta( $userdata->ID, 'wp-approve-user', true );
+		$status          = self::read_status_raw( $userdata->ID );
 		$has_status_meta = metadata_exists( 'user', $userdata->ID, 'wp-approve-user' );
 
 		/*
@@ -495,7 +585,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @param int $user_id ID of the newly registered user.
 	 */
 	public function auto_approve_user( $user_id ) {
-		if ( 'pending' !== get_user_meta( $user_id, 'wp-approve-user', true ) ) {
+		if ( 'pending' !== self::read_status_raw( $user_id ) ) {
 			return;
 		}
 
@@ -664,7 +754,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @return array Filtered email arguments.
 	 */
 	public function wp_new_user_notification_email_admin( $email, $user, $blogname ) {
-		if ( 'pending' !== get_user_meta( $user->ID, 'wp-approve-user', true ) ) {
+		if ( 'pending' !== self::read_status_raw( $user->ID ) ) {
 			return $email;
 		}
 
@@ -695,7 +785,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 * @param int $user_id ID of the newly registered user.
 	 */
 	public function register_new_user( $user_id ) {
-		if ( 'pending' === get_user_meta( $user_id, 'wp-approve-user', true ) ) {
+		if ( 'pending' === self::read_status_raw( $user_id ) ) {
 			remove_action( 'register_new_user', 'wp_send_new_user_notifications' );
 			add_action( 'register_new_user', 'wp_new_user_notification' );
 		}
@@ -1088,7 +1178,7 @@ class Obenland_Wp_Approve_User extends Obenland_Wp_Plugins_V5 {
 	 */
 	public function delete_user( $user_id ) {
 		$is_new_registration = get_user_meta( $user_id, 'wp-approve-user-new-registration', true );
-		$is_unapproved       = 'unapproved' === get_user_meta( $user_id, 'wp-approve-user', true );
+		$is_unapproved       = 'unapproved' === self::read_status_raw( $user_id );
 
 		if ( $is_new_registration && $is_unapproved && $this->options['wpau-send-unapprove-email'] ) {
 			$user     = new WP_User( $user_id );

--- a/class-wpau-dashboard-widget.php
+++ b/class-wpau-dashboard-widget.php
@@ -318,7 +318,7 @@ class WPAU_Dashboard_Widget {
 			wp_send_json_error( array( 'code' => 'out_of_scope' ), 404 );
 		}
 
-		$stale = 'pending' !== get_user_meta( $user_id, 'wp-approve-user', true );
+		$stale = 'pending' !== Obenland_Wp_Approve_User::read_status_raw( $user_id );
 		if ( ! $stale ) {
 			Obenland_Wp_Approve_User::mark_approved( $user_id );
 		}
@@ -353,7 +353,7 @@ class WPAU_Dashboard_Widget {
 			wp_send_json_error( array( 'code' => 'out_of_scope' ), 404 );
 		}
 
-		$stale = 'pending' !== get_user_meta( $user_id, 'wp-approve-user', true );
+		$stale = 'pending' !== Obenland_Wp_Approve_User::read_status_raw( $user_id );
 		if ( ! $stale ) {
 			Obenland_Wp_Approve_User::mark_unapproved( $user_id );
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-approve-user",
-	"version": "13.0.0",
+	"version": "14.0.0",
 	"private": true,
 	"description": "Adds an approval step before new WordPress users can log in.",
 	"author": "Konstantin Obenland",

--- a/tests/test-abilities.php
+++ b/tests/test-abilities.php
@@ -138,7 +138,7 @@ class WPAU_Abilities_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( static::$subscriber_id, $result['user_id'] );
 		$this->assertSame( 'approved', $result['status'] );
-		$this->assertSame( 'approved', get_user_meta( static::$subscriber_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( static::$subscriber_id ) );
 		$this->assertSame( array( static::$subscriber_id ), $fired );
 	}
 
@@ -164,7 +164,7 @@ class WPAU_Abilities_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( static::$subscriber_id, $result['user_id'] );
 		$this->assertSame( 'unapproved', $result['status'] );
-		$this->assertSame( 'unapproved', get_user_meta( static::$subscriber_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( static::$subscriber_id ) );
 		$this->assertSame( array( static::$subscriber_id ), $fired );
 	}
 

--- a/tests/test-auto-approval.php
+++ b/tests/test-auto-approval.php
@@ -114,7 +114,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 			$instance = new Obenland_Wp_Approve_User();
 			$instance->auto_approve_user( $user->ID );
 
-			$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 			$this->assertSame( array( $user->ID ), $fired );
 		} finally {
 			remove_action( 'wpau_approve', $listener );
@@ -142,7 +142,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -166,7 +166,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -195,7 +195,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 			$instance = new Obenland_Wp_Approve_User();
 			$instance->auto_approve_user( $user->ID );
 
-			$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		} finally {
 			remove_filter( 'wpau_auto_approve_rules', $filter );
 		}
@@ -235,7 +235,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 			$instance->auto_approve_user( $user->ID );
 
 			$this->assertSame( 1, $count );
-			$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		} finally {
 			remove_action( 'wpau_approve', $listener );
 		}
@@ -255,7 +255,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -294,7 +294,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 			$instance->auto_approve_user( $user->ID );
 
 			$this->assertSame( 0, $fired );
-			$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		} finally {
 			remove_action( 'wpau_approve', $listener );
 		}
@@ -325,7 +325,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -428,7 +428,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -458,7 +458,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 			remove_filter( 'wpau_auto_approve_rules', $filter );
 		}
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -604,7 +604,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -628,7 +628,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -654,7 +654,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		$instance = new Obenland_Wp_Approve_User();
 		$instance->auto_approve_user( $user->ID );
 
-		$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -765,7 +765,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		try {
 			$instance = new Obenland_Wp_Approve_User();
 			$instance->auto_approve_user( $user->ID );
-			$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		} finally {
 			remove_filter( 'wpau_auto_approve_rules', $filter );
 		}
@@ -794,7 +794,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 		try {
 			$instance = new Obenland_Wp_Approve_User();
 			$instance->auto_approve_user( $user->ID );
-			$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		} finally {
 			remove_filter( 'wpau_auto_approve_rules', $filter );
 		}
@@ -830,7 +830,7 @@ class WPAU_Auto_Approval_Test extends WP_UnitTestCase {
 			$instance = new Obenland_Wp_Approve_User();
 			$instance->auto_approve_user( $user->ID );
 
-			$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+			$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		} finally {
 			remove_filter( 'wpau_default_options', $filter );
 		}

--- a/tests/test-cron-events.php
+++ b/tests/test-cron-events.php
@@ -25,8 +25,8 @@ class WPAU_Cron_Events_Test extends WP_UnitTestCase {
 		wp_clear_scheduled_hook( 'wpau_allowlist_users_cron' );
 		wpau_allowlist_users();
 
-		$this->assertSame( 'approved', get_user_meta( $user_one, 'wp-approve-user', true ) );
-		$this->assertSame( 'approved', get_user_meta( $user_two, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_one ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_two ) );
 		$this->assertSame( '1', get_user_meta( $user_one, 'wp-approve-user-mail-sent', true ) );
 		$this->assertFalse( wp_next_scheduled( 'wpau_allowlist_users_cron' ) );
 	}
@@ -77,7 +77,7 @@ class WPAU_Cron_Events_Test extends WP_UnitTestCase {
 		$this->assertSame( $total_users, $scheduled[0]->args[0] );
 
 		// The single user that existed must actually be flagged approved.
-		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user-mail-sent', true ) );
 	}
 
@@ -118,7 +118,7 @@ class WPAU_Cron_Events_Test extends WP_UnitTestCase {
 		$all_ids      = get_users( array( 'fields' => 'ID' ) );
 		$before_state = array();
 		foreach ( $all_ids as $id ) {
-			$before_state[ $id ] = get_user_meta( $id, 'wp-approve-user', true );
+			$before_state[ $id ] = Obenland_Wp_Approve_User::read_status_raw( $id );
 		}
 
 		$expected_flipped = get_users(
@@ -133,7 +133,7 @@ class WPAU_Cron_Events_Test extends WP_UnitTestCase {
 		wpau_allowlist_users( 2 );
 
 		foreach ( $expected_flipped as $id ) {
-			$this->assertSame( 'approved', get_user_meta( $id, 'wp-approve-user', true ) );
+			$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $id ) );
 		}
 
 		foreach ( $all_ids as $id ) {
@@ -141,7 +141,7 @@ class WPAU_Cron_Events_Test extends WP_UnitTestCase {
 				continue;
 			}
 			/* Users before the offset are untouched by this run. */
-			$this->assertSame( $before_state[ $id ], get_user_meta( $id, 'wp-approve-user', true ) );
+			$this->assertSame( $before_state[ $id ], Obenland_Wp_Approve_User::read_status_raw( $id ) );
 		}
 
 		wp_clear_scheduled_hook( 'wpau_allowlist_users_cron' );

--- a/tests/test-dashboard-widget-ajax.php
+++ b/tests/test-dashboard-widget-ajax.php
@@ -110,7 +110,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 			remove_action( 'wpau_approve', $listener );
 		}
 
-		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 		$this->assertSame( array( $user_id ), $fired );
 		$this->assertTrue( $response['success'] );
 		$this->assertSame( $user_id, $response['data']['user_id'] );
@@ -173,7 +173,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 	public function test_ajax_approve_rejects_mismatched_user_nonce() {
 		$target_id     = $this->make_pending( 'target@example.test' );
 		$other_id      = $this->make_pending( 'other@example.test' );
-		$other_pending = get_user_meta( $target_id, 'wp-approve-user', true );
+		$other_pending = Obenland_Wp_Approve_User::read_status_raw( $target_id );
 
 		$_POST['action']  = 'wpau_dashboard_approve';
 		$_POST['user_id'] = $target_id;
@@ -185,7 +185,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 		} finally {
 			$this->assertSame(
 				$other_pending,
-				get_user_meta( $target_id, 'wp-approve-user', true ),
+				Obenland_Wp_Approve_User::read_status_raw( $target_id ),
 				'Target user must not be mutated when the nonce is for a different user.'
 			);
 		}
@@ -219,7 +219,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 			remove_action( 'wpau_unapprove', $listener );
 		}
 
-		$this->assertSame( 'unapproved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 		$this->assertEmpty( WP_Session_Tokens::get_instance( $user_id )->get_all() );
 		$this->assertSame( array( $user_id ), $fired );
 		$this->assertTrue( $response['success'] );
@@ -249,7 +249,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 			$this->expectException( WPAjaxDieStopException::class );
 			$this->_handleAjax( 'wpau_dashboard_approve' );
 		} finally {
-			$this->assertSame( 'pending', get_user_meta( $user_id, 'wp-approve-user', true ) );
+			$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 			$this->assertSame( 0, $fired );
 		}
 	}
@@ -344,7 +344,7 @@ class WPAU_Dashboard_Widget_Ajax_Test extends WP_Ajax_UnitTestCase {
 			$this->expectException( WPAjaxDieStopException::class );
 			$this->_handleAjax( 'wpau_dashboard_unapprove' );
 		} finally {
-			$this->assertSame( 'pending', get_user_meta( $user_id, 'wp-approve-user', true ) );
+			$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 			$this->assertSame( 0, $fired );
 		}
 	}

--- a/tests/test-main-class.php
+++ b/tests/test-main-class.php
@@ -1034,7 +1034,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'update=wpau-approved', $e->location );
 		}
 
-		$this->assertSame( 'approved', get_user_meta( self::$subscriber->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( self::$subscriber->ID ) );
 	}
 
 	/**
@@ -1082,7 +1082,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'update=wpau-unapproved', $e->location );
 		}
 
-		$this->assertSame( 'unapproved', get_user_meta( self::$subscriber->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( self::$subscriber->ID ) );
 	}
 
 	/**
@@ -1107,7 +1107,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'update=wpau-approved', $e->location );
 		}
 
-		$this->assertSame( 'approved', get_user_meta( self::$subscriber->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( self::$subscriber->ID ) );
 	}
 
 	/**
@@ -1151,7 +1151,7 @@ class WPAU_Main_Class_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'approved',
-			get_user_meta( self::$subscriber->ID, 'wp-approve-user', true )
+			Obenland_Wp_Approve_User::read_status_raw( self::$subscriber->ID )
 		);
 	}
 

--- a/tests/test-mark-helpers.php
+++ b/tests/test-mark-helpers.php
@@ -48,7 +48,7 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 			remove_action( 'wpau_approve', $listener );
 		}
 
-		$this->assertSame( 'approved', get_user_meta( self::$user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( self::$user->ID ) );
 		$this->assertSame( array( self::$user->ID ), $fired );
 	}
 
@@ -78,7 +78,7 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( 1, $fired );
-		$this->assertSame( 'approved', get_user_meta( self::$user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( self::$user->ID ) );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( 1, $fired );
-		$this->assertSame( 'unapproved', get_user_meta( self::$user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( self::$user->ID ) );
 	}
 
 	/**
@@ -130,7 +130,7 @@ class WPAU_Mark_Helpers_Test extends WP_UnitTestCase {
 			remove_action( 'wpau_unapprove', $listener );
 		}
 
-		$this->assertSame( 'unapproved', get_user_meta( self::$user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( self::$user->ID ) );
 		$this->assertEmpty( WP_Session_Tokens::get_instance( self::$user->ID )->get_all() );
 		$this->assertSame( array( self::$user->ID ), $fired );
 	}

--- a/tests/test-noop.php
+++ b/tests/test-noop.php
@@ -33,8 +33,8 @@ class WPAU_Noop_Test extends WP_UnitTestCase {
 		delete_user_meta( $user_two, 'wp-approve-user' );
 
 		$this->assertSame( 1, wpau_whitelist_users( 1 ) );
-		$this->assertSame( 'approved', get_user_meta( $user_one, 'wp-approve-user', true ) );
-		$this->assertSame( 'approved', get_user_meta( $user_two, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_one ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_two ) );
 		$this->assertSame( '1', get_user_meta( $user_one, 'wp-approve-user-mail-sent', true ) );
 	}
 

--- a/tests/test-plugin-loader.php
+++ b/tests/test-plugin-loader.php
@@ -38,7 +38,7 @@ class WPAU_Plugin_Loader_Test extends WP_UnitTestCase {
 
 		wp_approve_user_activate();
 
-		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 
 		/*
 		 * wpau_allowlist_users() schedules with `array( $processed )` args, so

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -54,7 +54,7 @@ class WPAU_Uninstall_Test extends WP_UnitTestCase {
 		include dirname( __DIR__ ) . '/uninstall.php';
 
 		$this->assertFalse( get_option( 'wp-approve-user' ) );
-		$this->assertSame( '', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( '', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 		$this->assertSame( '', get_user_meta( $user_id, 'wp-approve-user-mail-sent', true ) );
 		$this->assertSame( '', get_user_meta( $user_id, 'wp-approve-user-new-registration', true ) );
 		$this->assertSame( '', get_user_meta( $user_id, 'wp-approve-user-ip', true ) );

--- a/tests/test-upgrade.php
+++ b/tests/test-upgrade.php
@@ -63,7 +63,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		wpau_upgrade_all();
 
 		$this->assertSame( $wpau_db_version, (int) get_site_option( 'wpau_db_version' ) );
-		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 	}
 
 	/**
@@ -81,7 +81,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 
 		wpau_upgrade_all();
 
-		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( '1', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 	}
 
 	/**
@@ -126,7 +126,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		remove_filter( 'pre_update_option', $guard );
 		remove_filter( 'pre_site_option_wpau_db_version', $stringify );
 
-		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( '1', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 	}
 
 	/**
@@ -140,7 +140,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 
 		wpau_upgrade_to_12();
 
-		$this->assertSame( 'pending', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 	}
 
 	/**
@@ -161,10 +161,10 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 
 		wpau_upgrade_to_13();
 
-		$this->assertSame( 'approved', get_user_meta( $missing, 'wp-approve-user', true ) );
-		$this->assertSame( 'approved', get_user_meta( $approved, 'wp-approve-user', true ) );
-		$this->assertSame( 'pending', get_user_meta( $pending, 'wp-approve-user', true ) );
-		$this->assertSame( 'unapproved', get_user_meta( $unapproved, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $missing ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $approved ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $pending ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( $unapproved ) );
 	}
 
 	/**
@@ -193,7 +193,7 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		wpau_upgrade_to_13();
 
 		foreach ( $ids as $id ) {
-			$this->assertSame( 'approved', get_user_meta( $id, 'wp-approve-user', true ) );
+			$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $id ) );
 		}
 	}
 
@@ -215,8 +215,8 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		wpau_upgrade_all();
 
 		$this->assertSame( $wpau_db_version, (int) get_site_option( 'wpau_db_version' ) );
-		$this->assertSame( 'approved', get_user_meta( $legacy, 'wp-approve-user', true ) );
-		$this->assertSame( 'approved', get_user_meta( $missing, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $legacy ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $missing ) );
 	}
 
 	/**
@@ -237,8 +237,8 @@ class WPAU_Upgrade_Test extends WP_UnitTestCase {
 		wpau_upgrade_all();
 
 		// v12 migration did NOT run; true stays as '1'.
-		$this->assertSame( '1', get_user_meta( $legacy, 'wp-approve-user', true ) );
+		$this->assertSame( '1', Obenland_Wp_Approve_User::read_status_raw( $legacy ) );
 		// v13 migration DID run; missing-meta user is now approved.
-		$this->assertSame( 'approved', get_user_meta( $missing, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $missing ) );
 	}
 }

--- a/tests/test-user-meta.php
+++ b/tests/test-user-meta.php
@@ -63,7 +63,7 @@ class User_Meta extends WP_UnitTestCase {
 
 		$class->user_register( $user_id );
 
-		$this->assertSame( 'approved', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user-new-registration', true ) );
 	}
 
@@ -80,7 +80,7 @@ class User_Meta extends WP_UnitTestCase {
 
 		$class->user_register( $user_id );
 
-		$this->assertSame( 'pending', get_user_meta( $user_id, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user_id ) );
 		$this->assertSame( '1', get_user_meta( $user_id, 'wp-approve-user-new-registration', true ) );
 	}
 
@@ -97,7 +97,7 @@ class User_Meta extends WP_UnitTestCase {
 
 		$class->user_register( $user->ID );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		$this->assertSame( '1', get_user_meta( $user->ID, 'wp-approve-user-new-registration', true ) );
 	}
 
@@ -133,7 +133,7 @@ class User_Meta extends WP_UnitTestCase {
 	public function test_wp_authenticate_user_missing_meta_is_treated_as_approved() {
 		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
 		// No meta set at all — this is the pre-plugin-install state.
-		$this->assertSame( '', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( '', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 
 		$class  = new Obenland_Wp_Approve_User();
 		$result = $class->wp_authenticate_user( $user );
@@ -173,7 +173,7 @@ class User_Meta extends WP_UnitTestCase {
 		// phpcs:enable WordPress.DB
 		wp_cache_delete( $user->ID, 'user_meta' );
 
-		$this->assertSame( '', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( '', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 		$this->assertTrue( metadata_exists( 'user', $user->ID, 'wp-approve-user' ) );
 
 		$class  = new Obenland_Wp_Approve_User();
@@ -215,7 +215,7 @@ class User_Meta extends WP_UnitTestCase {
 		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
 		update_user_meta( $user->ID, 'wp-approve-user', true );
 
-		$this->assertSame( 'approved', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -230,7 +230,7 @@ class User_Meta extends WP_UnitTestCase {
 		$user = static::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
 		update_user_meta( $user->ID, 'wp-approve-user', false );
 
-		$this->assertSame( 'pending', get_user_meta( $user->ID, 'wp-approve-user', true ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user->ID ) );
 	}
 
 	/**
@@ -252,10 +252,10 @@ class User_Meta extends WP_UnitTestCase {
 		update_user_meta( $zero_int, 'wp-approve-user', 0 );
 		update_user_meta( $zero_str, 'wp-approve-user', '0' );
 
-		$this->assertSame( 'approved', get_user_meta( $one_int, 'wp-approve-user', true ) );
-		$this->assertSame( 'approved', get_user_meta( $one_string, 'wp-approve-user', true ) );
-		$this->assertSame( 'pending', get_user_meta( $zero_int, 'wp-approve-user', true ) );
-		$this->assertSame( 'pending', get_user_meta( $zero_str, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $one_int ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $one_string ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $zero_int ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $zero_str ) );
 	}
 
 	/**
@@ -275,9 +275,9 @@ class User_Meta extends WP_UnitTestCase {
 		update_user_meta( $unapproved, 'wp-approve-user', 'unapproved' );
 		update_user_meta( $pending, 'wp-approve-user', 'pending' );
 
-		$this->assertSame( 'approved', get_user_meta( $approved, 'wp-approve-user', true ) );
-		$this->assertSame( 'unapproved', get_user_meta( $unapproved, 'wp-approve-user', true ) );
-		$this->assertSame( 'pending', get_user_meta( $pending, 'wp-approve-user', true ) );
+		$this->assertSame( 'approved', Obenland_Wp_Approve_User::read_status_raw( $approved ) );
+		$this->assertSame( 'unapproved', Obenland_Wp_Approve_User::read_status_raw( $unapproved ) );
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $pending ) );
 	}
 
 	/**
@@ -293,7 +293,7 @@ class User_Meta extends WP_UnitTestCase {
 		$user = static::factory()->user->create();
 		update_user_meta( $user, 'wp-approve-user', 'banana' );
 
-		$this->assertSame( 'banana', get_user_meta( $user, 'wp-approve-user', true ) );
+		$this->assertSame( 'banana', Obenland_Wp_Approve_User::read_status_raw( $user ) );
 	}
 
 	/**
@@ -352,5 +352,111 @@ class User_Meta extends WP_UnitTestCase {
 
 		$result = $class->wp_authenticate_user( $user );
 		$this->assertSame( $user, $result );
+	}
+
+	/**
+	 * Third-party integrations (most notably Restrict Content Pro) read the
+	 * meta with `! get_user_meta( $id, 'wp-approve-user', true )` to decide
+	 * whether a user is pending. With raw three-state strings every state is
+	 * truthy, so pending/unapproved users sneak past the gate. The read
+	 * filter has to translate canonical strings back to legacy booleans so
+	 * that consumer pattern still works.
+	 *
+	 * @covers ::translate_status_read
+	 */
+	public function test_read_filter_translates_pending_to_false() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+		update_user_meta( $user, 'wp-approve-user', 'pending' );
+
+		$this->assertFalse( get_user_meta( $user, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Unapproved users must also surface as legacy-falsy so RCP's
+	 * `is_pending()` check blocks them from restricted content.
+	 *
+	 * @covers ::translate_status_read
+	 */
+	public function test_read_filter_translates_unapproved_to_false() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+		update_user_meta( $user, 'wp-approve-user', 'unapproved' );
+
+		$this->assertFalse( get_user_meta( $user, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Approved users must surface as legacy-truthy.
+	 *
+	 * @covers ::translate_status_read
+	 */
+	public function test_read_filter_translates_approved_to_true() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+		update_user_meta( $user, 'wp-approve-user', 'approved' );
+
+		$this->assertTrue( get_user_meta( $user, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Users without any meta row must continue to return the empty default
+	 * `get_user_meta()` produces — the filter only translates canonical
+	 * values, it doesn't synthesize state.
+	 *
+	 * @covers ::translate_status_read
+	 */
+	public function test_read_filter_passes_missing_meta_through() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+
+		$this->assertSame( '', get_user_meta( $user, 'wp-approve-user', true ) );
+	}
+
+	/**
+	 * Other meta keys must be untouched by the wp-approve-user read filter.
+	 *
+	 * @covers ::translate_status_read
+	 */
+	public function test_read_filter_ignores_other_meta_keys() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+		update_user_meta( $user, 'wp-approve-user-mail-sent', 'pending' );
+
+		$this->assertSame( 'pending', get_user_meta( $user, 'wp-approve-user-mail-sent', true ) );
+	}
+
+	/**
+	 * The `read_status_raw()` helper must bypass the legacy boolean filter
+	 * so plugin internals keep seeing the canonical three-state string.
+	 *
+	 * @covers ::read_status_raw
+	 */
+	public function test_read_status_raw_returns_canonical_string() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+		update_user_meta( $user, 'wp-approve-user', 'pending' );
+
+		$this->assertSame( 'pending', Obenland_Wp_Approve_User::read_status_raw( $user ) );
+	}
+
+	/**
+	 * The `read_status_raw()` helper returns an empty string when no meta
+	 * row exists, matching `get_user_meta()`'s contract for missing keys.
+	 *
+	 * @covers ::read_status_raw
+	 */
+	public function test_read_status_raw_returns_empty_string_for_missing_meta() {
+		new Obenland_Wp_Approve_User();
+
+		$user = static::factory()->user->create();
+
+		$this->assertSame( '', Obenland_Wp_Approve_User::read_status_raw( $user ) );
 	}
 }

--- a/wp-approve-user.php
+++ b/wp-approve-user.php
@@ -3,12 +3,12 @@
  * Plugin Name: WP Approve User
  * Plugin URI:  http://en.wp.obenland.it/wp-approve-user/#utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-approve-user
  * Description: Adds action links to user table to approve or unapprove user registrations.
- * Version:     13
+ * Version:     14
  * Author:      Konstantin Obenland
  * Author URI:  http://en.wp.obenland.it/#utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-approve-user
  * Text Domain: wp-approve-user
  * Domain Path: /lang
- * Requires at least: 4.7
+ * Requires at least: 5.5
  * Requires PHP: 7.4
  * License:     GPLv2
  *


### PR DESCRIPTION
## Summary

- V13 (#70) normalized boolean **writes** to the `wp-approve-user` meta via `register_meta()`'s `sanitize_callback`, but **reads** still returned the canonical three-state strings. Since `'approved'`, `'pending'`, and `'unapproved'` are all truthy, integrations like [Restrict Content Pro](https://github.com/stellarwp/restrict-content/blob/2b18f41e58c4e6bcab4d8447c7f01a49e1cb9200/core/includes/integrations/class-rcp-wp-approve-user.php#L63) that gate users with `! get_user_meta( $id, 'wp-approve-user', true )` saw every user as approved and let pending/unapproved accounts past their gate. v13 fixed half the bridge.
- Add a `get_user_metadata` filter that translates the stored string back to the legacy boolean (`'approved'` → `true`, `'pending'`/`'unapproved'` → `false`), and a new `Obenland_Wp_Approve_User::read_status_raw()` helper that plugin internals call instead. Both share a single static reentrancy flag because `get_metadata_raw()` fires the same `get_{type}_metadata` short-circuit hook and would otherwise recurse into us forever (SIGKILL on first run). The flag is set/cleared inside `try`/`finally` so an unexpected throw can't leave it stuck for the rest of the request.
- Switched every internal status read (login gate, auto-approval, dashboard widget, abilities, row actions, notification mails) onto `read_status_raw()` so the canonical-string comparisons keep working.
- Bumped `Requires at least: 5.5` (for `get_metadata_raw()`) and the plugin version to 14.

## Test plan

- [x] PHPUnit single-site: `202 tests / 494 assertions`, 0 failures.
- [x] PHPUnit multisite: `202 tests / 511 assertions`, 0 failures.
- [x] PHPCS clean.
- [x] JS / CSS / Markdown / package.json lint clean.
- [x] New tests in `tests/test-user-meta.php` lock in the RCP read pattern: pending/unapproved → `false`, approved → `true`, missing meta → `''`, other meta keys untouched, and the `read_status_raw()` helper returns the canonical string and `''` for missing rows.