### PR TITLE
Bump Tested up to 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: obenland
 Tags: admin, user, login, approve, user management
 Donate link: <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G65Y5CM3HVRNY>
 Requires at least: 6.4
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 13
 License: GPLv2 or later


### PR DESCRIPTION
WordPress 7.1 is the latest stable release.

Bumps `Tested up to` in README.md from 7.0 to 7.1 (major.minor of 7.1).